### PR TITLE
Fix exponential, clean binomial

### DIFF
--- a/src/distributions/binomial.jl
+++ b/src/distributions/binomial.jl
@@ -45,7 +45,7 @@ lognormalizer(params::NaturalParameters{Binomial}) = get_conditioner(params)log(
 
 basemeasure(d::NaturalParameters{Binomial}, x) =
     typeof(x) <: Integer ? binomial(get_conditioner(d), x) : error("x must be integer")
-basemeasure(d::Binomial, x) = typeof(x) <: Integer ? binomial(d.n, x) : error("x must be integer")
+
 function basemeasure(d::Binomial, x)
     binomial(d.n, x)
 end

--- a/src/distributions/exponential.jl
+++ b/src/distributions/exponential.jl
@@ -35,6 +35,6 @@ function lognormalizer(η::NaturalParameters{Exponential})
     return -log(-first(get_params(η)))
 end
 
-isproper(::Type{<:Exponential}, parms) = (first(params) <= 0)
+isproper(params::NaturalParameters{Exponential}) = (first(get_params(params)) <= 0)
 basemeasure(::Union{<:NaturalParameters{Exponential}, <:Exponential}, x) = 1.0
 plus(::NaturalParameters{Exponential}, ::NaturalParameters{Exponential}) = Plus()

--- a/test/distributions/test_exponential.jl
+++ b/test/distributions/test_exponential.jl
@@ -26,6 +26,11 @@ import ExponentialFamily: mirrorlog, NaturalParameters, get_params, basemeasure
         @test prod(ProdAnalytical(), Exponential(0.1), Exponential(0.1)) ≈ Exponential(0.05)
     end
 
+    @testset "isproper" begin
+        @test isproper(NaturalParameters(Exponential, [-5.0])) === true
+        @test isproper(NaturalParameters(Exponential, [1.0])) === false
+    end
+
     @testset "mean(::typeof(log))" begin
         @test mean(log, Exponential(1)) ≈ -MathConstants.eulergamma
         @test mean(log, Exponential(10)) ≈ 1.7253694280925127


### PR DESCRIPTION
This PR fixes and adds tests for `isproper` function for Exponential distribution.

Additionally, `basemeasure` for Binomial from `Distributions.jl` was removed.