### PR TITLE
fix `rand` ambiguity 

### DIFF
--- a/src/exponential_family.jl
+++ b/src/exponential_family.jl
@@ -836,6 +836,8 @@ BayesBase.kurtosis(ef::ExponentialFamilyDistribution{T}) where {T <: Distributio
 BayesBase.rand(ef::ExponentialFamilyDistribution, args...) = rand(Random.default_rng(), ef, args...)
 BayesBase.rand!(ef::ExponentialFamilyDistribution, args...) = rand!(Random.default_rng(), ef, args...)
 
+BayesBase.rand(ef::ExponentialFamilyDistribution, args::Integer...) = rand(Random.default_rng(), ef, args...)
+
 BayesBase.rand(rng::AbstractRNG, ef::ExponentialFamilyDistribution{T}, args::Integer...) where {T <: Distribution} =
     rand(rng, convert(T, ef), args...)
 

--- a/test/distributions/distributions_setuptests.jl
+++ b/test/distributions/distributions_setuptests.jl
@@ -221,6 +221,7 @@ function run_test_basic_functions(distribution; nsamples = 10, test_gradients = 
         @test @inferred(mean(ef)) ≈ mean(distribution)
         @test @inferred(var(ef)) ≈ var(distribution)
         @test @inferred(std(ef)) ≈ std(distribution)
+        @test size(ExponentialFamily.check_logpdf(variate_form(typeof(ef)), typeof(x), eltype(x), ef, rand(ef, 10))[2])[end] === 10
         @test rand(StableRNG(42), ef) ≈ rand(StableRNG(42), distribution)
         @test all(rand(StableRNG(42), ef, 10) .≈ rand(StableRNG(42), distribution, 10))
         @test all(rand!(StableRNG(42), ef, [deepcopy(x) for _ in 1:10]) .≈ rand!(StableRNG(42), distribution, [deepcopy(x) for _ in 1:10]))

--- a/test/distributions/distributions_setuptests.jl
+++ b/test/distributions/distributions_setuptests.jl
@@ -221,7 +221,7 @@ function run_test_basic_functions(distribution; nsamples = 10, test_gradients = 
         @test @inferred(mean(ef)) ≈ mean(distribution)
         @test @inferred(var(ef)) ≈ var(distribution)
         @test @inferred(std(ef)) ≈ std(distribution)
-        @test size(rand(ef, 10))[end] === 10
+        @test last(size(rand(ef, 10))) === 10 # Test that `rand` without explicit `rng` works
         @test rand(StableRNG(42), ef) ≈ rand(StableRNG(42), distribution)
         @test all(rand(StableRNG(42), ef, 10) .≈ rand(StableRNG(42), distribution, 10))
         @test all(rand!(StableRNG(42), ef, [deepcopy(x) for _ in 1:10]) .≈ rand!(StableRNG(42), distribution, [deepcopy(x) for _ in 1:10]))

--- a/test/distributions/distributions_setuptests.jl
+++ b/test/distributions/distributions_setuptests.jl
@@ -221,7 +221,7 @@ function run_test_basic_functions(distribution; nsamples = 10, test_gradients = 
         @test @inferred(mean(ef)) ≈ mean(distribution)
         @test @inferred(var(ef)) ≈ var(distribution)
         @test @inferred(std(ef)) ≈ std(distribution)
-        @test size(ExponentialFamily.check_logpdf(variate_form(typeof(ef)), typeof(x), eltype(x), ef, rand(ef, 10))[2])[end] === 10
+        @test size(rand(ef, 10))[end] === 10
         @test rand(StableRNG(42), ef) ≈ rand(StableRNG(42), distribution)
         @test all(rand(StableRNG(42), ef, 10) .≈ rand(StableRNG(42), distribution, 10))
         @test all(rand!(StableRNG(42), ef, [deepcopy(x) for _ in 1:10]) .≈ rand!(StableRNG(42), distribution, [deepcopy(x) for _ in 1:10]))


### PR DESCRIPTION
This PR aims to fix https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/184