### PR TITLE
Fix VonMises inplace prod and tests

### DIFF
--- a/src/distributions/von_mises.jl
+++ b/src/distributions/von_mises.jl
@@ -21,20 +21,6 @@ function BayesBase.prod(::PreserveTypeProd{Distribution}, left::VonMises, right:
     return VonMises(α+ π*phase, R)
 end
 
-function BayesBase.prod!(
-    container::ExponentialFamilyDistribution{T},
-    left::ExponentialFamilyDistribution{T},
-    right::ExponentialFamilyDistribution{T}
-) where {T <: VonMises}
-    LoopVectorization.vmap!(
-        +,
-        getnaturalparameters(container),
-        getnaturalparameters(left),
-        getnaturalparameters(right)
-    )
-    return container
-end
-
 function BayesBase.prod(
     ::PreserveTypeProd{ExponentialFamilyDistribution},
     left::ExponentialFamilyDistribution{T},
@@ -42,9 +28,10 @@ function BayesBase.prod(
 ) where {T <: VonMises}
     conditionerleft = getconditioner(left)
     conditionerright = getconditioner(right)
-    F = promote_type(eltype(getnaturalparameters(left)), eltype(getnaturalparameters(right)))
-    container = ExponentialFamilyDistribution(VonMises, zeros(F, 2), conditionerleft + conditionerright, nothing)
-    return BayesBase.prod!(container, left, right)
+    ηleft = getnaturalparameters(left)
+    ηright = getnaturalparameters(right)
+   
+    return ExponentialFamilyDistribution(VonMises,ηright + ηleft , conditionerleft + conditionerright, nothing)
      
 end
 

--- a/src/distributions/von_mises.jl
+++ b/src/distributions/von_mises.jl
@@ -11,7 +11,7 @@ function BayesBase.prod(::PreserveTypeProd{Distribution}, left::VonMises, right:
     μright, κright = params(right)
 
     a = κleft * cos(μleft) + κright * cos(μright)
-    b = (κleft * sin(μleft) + κright * sin(μright))
+    b = κleft * sin(μleft) + κright * sin(μright)
 
     R = sqrt(a^2 + b^2)
     α = asin(b / R)

--- a/test/distributions/vonmises_tests.jl
+++ b/test/distributions/vonmises_tests.jl
@@ -1,4 +1,3 @@
-
 # VonMises comes from Distributions.jl and most of the things should be covered there
 # Here we test some extra ExponentialFamily.jl specific functionality
 
@@ -42,25 +41,13 @@ end
 
 @testitem "VonMises: prod with Distributions" begin
     include("distributions_setuptests.jl")
-
-    function prod_result_parameters(paramsleft, paramsright)
-        (μleft, κleft) = paramsleft
-        (μright, κright) = paramsright
-        a = κleft * cos(μleft) + κright * cos(μright)
-        b = κleft * sin(μleft) + κright * sin(μright)
-
-        R = sqrt(a^2 + b^2)
-        α = atan(b / a)
-
-        return α, R
-    end
-    (μ1, κ1) = prod_result_parameters((3.0, 2.0), (2.0, 1.0))
-    (μ2, κ2) = prod_result_parameters((7.0, 1.0), (0.1, 4.5))
-    (μ3, κ3) = prod_result_parameters((1.0, 3.0), (0.2, 0.4))
-    for strategy in (ClosedProd(), PreserveTypeProd(Distribution), PreserveTypeLeftProd(), PreserveTypeRightProd(), GenericProd())
-        @test prod(strategy, VonMises(3.0, 2.0), VonMises(2.0, 1.0)) ≈ VonMises(μ1, κ1)
-        @test prod(strategy, VonMises(7.0, 1.0), VonMises(0.1, 4.5)) ≈ VonMises(μ2, κ2)
-        @test prod(strategy, VonMises(1.0, 3.0), VonMises(0.2, 0.4)) ≈ VonMises(μ3, κ3)
+    for dist1 in [VonMises(10randn(),10rand()) for _=1:20], dist2 in [VonMises(10randn(),10rand()) for _=1:20]
+        ef1 = convert(ExponentialFamilyDistribution,dist1)
+        ef2 = convert(ExponentialFamilyDistribution,dist2)
+        prod_ef = prod(GenericProd(),ef1,ef2)
+        for strategy in (ClosedProd(), PreserveTypeProd(Distribution), PreserveTypeLeftProd(), PreserveTypeRightProd(), GenericProd())
+            @test prod(strategy, dist1, dist2) ≈ convert(Distribution,prod_ef)
+        end
     end
 end
 


### PR DESCRIPTION
VonMises inplace prod was not considering the conditioners. The PR augments the product with the conditioner. Test suite is changed such that the products in mean and natural spaces are checked against each other. 