### PR TITLE
Fix Chisq isproper

### DIFF
--- a/src/distributions/chi_squared.jl
+++ b/src/distributions/chi_squared.jl
@@ -37,7 +37,7 @@ end
 
 # Natural parametrization
 
-isproper(::NaturalParametersSpace, ::Type{Chisq}, η, conditioner) = isnothing(conditioner) && length(η) === 1 && all(>(-1 / 2), η) && all(!isinf, η)
+isproper(::NaturalParametersSpace, ::Type{Chisq}, η, conditioner) = isnothing(conditioner) && length(η) === 1 && all(>(-1), η) && all(!isinf, η)
 isproper(::MeanParametersSpace, ::Type{Chisq}, θ, conditioner) =
     isnothing(conditioner) && length(θ) === 1 && all(>(0), θ) && all(!isinf, θ)
 

--- a/test/distributions/chi_squared_tests.jl
+++ b/test/distributions/chi_squared_tests.jl
@@ -30,6 +30,7 @@
     ## mean parameter should be integer in the MeanParametersSpace
     @test isproper(MeanParametersSpace(), Chisq, [0.1])
     @test isproper(NaturalParametersSpace(), Chisq, [-0.5])
+    @test convert(ExponentialFamilyDistribution, Chisq(0.5)) ≈ ExponentialFamilyDistribution(Chisq, [-0.75])
     @test_throws Exception convert(ExponentialFamilyDistribution, Chisq(Inf))
 end
 

--- a/test/distributions/chi_squared_tests.jl
+++ b/test/distributions/chi_squared_tests.jl
@@ -29,6 +29,7 @@
 
     ## mean parameter should be integer in the MeanParametersSpace
     @test isproper(MeanParametersSpace(), Chisq, [0.1])
+    @test isproper(NaturalParametersSpace(), Chisq, [-0.5])
     @test_throws Exception convert(ExponentialFamilyDistribution, Chisq(Inf))
 end
 

--- a/test/distributions/chi_squared_tests.jl
+++ b/test/distributions/chi_squared_tests.jl
@@ -30,6 +30,7 @@
     ## mean parameter should be integer in the MeanParametersSpace
     @test isproper(MeanParametersSpace(), Chisq, [0.1])
     @test isproper(NaturalParametersSpace(), Chisq, [-0.5])
+    @test !isproper(NaturalParametersSpace(), Chisq, [-1.5])
     @test convert(ExponentialFamilyDistribution, Chisq(0.5)) ≈ ExponentialFamilyDistribution(Chisq, [-0.75])
     @test_throws Exception convert(ExponentialFamilyDistribution, Chisq(Inf))
 end

--- a/test/distributions/dirichlet_tests.jl
+++ b/test/distributions/dirichlet_tests.jl
@@ -31,13 +31,14 @@ end
 @testitem "Dirichlet: ExponentialFamilyDistribution" begin
     include("distributions_setuptests.jl")
 
+    rng = StableRNG(42)
     for len in 3:5
-        α = rand(StableRNG(42), len)
+        α = rand(rng, len)
         @testset let d = Dirichlet(α)
             ef = test_exponentialfamily_interface(d; option_assume_no_allocations = false)
             η1 = getnaturalparameters(ef)
 
-            for x in [rand(len) for _ in 1:3]
+            for x in [rand(rng, len) for _ in 1:3]
                 x = x ./ sum(x)
                 @test @inferred(isbasemeasureconstant(ef)) === ConstantBaseMeasure()
                 @test @inferred(basemeasure(ef, x)) === 1.0
@@ -67,17 +68,17 @@ end
 
     for strategy in (ClosedProd(), PreserveTypeProd(Distribution), PreserveTypeLeftProd(), PreserveTypeRightProd(), GenericProd())
         @test @inferred(prod(strategy, Dirichlet([1.0, 1.0, 1.0]), Dirichlet([1.0, 1.0, 1.0]))) ≈ Dirichlet([1.0, 1.0, 1.0])
-        @test @inferred(prod(strategy, Dirichlet([1.1, 1.0, 2.0]), Dirichlet([1.0, 1.2, 1.0]))) ≈ Dirichlet([1.1, 1.2000000000000002, 2.0])
-        @test @inferred(prod(strategy, Dirichlet([1.1, 2.0, 2.0]), Dirichlet([3.0, 1.2, 5.0]))) ≈ Dirichlet([3.0999999999999996, 2.2, 6.0])
+        @test @inferred(prod(strategy, Dirichlet([1.1, 1.0, 2.0]), Dirichlet([1.0, 1.2, 1.0]))) ≈ Dirichlet([1.1, 1.2, 2.0])
+        @test @inferred(prod(strategy, Dirichlet([1.1, 2.0, 2.0]), Dirichlet([3.0, 1.2, 5.0]))) ≈ Dirichlet([3.1, 2.2, 6.0])
     end
 end
 
 @testitem "Dirichlet: prod with ExponentialFamilyDistribution" begin
     include("distributions_setuptests.jl")
-
+    rng = StableRNG(123)
     for len in 3:6
-        αleft = rand(len) .+ 1
-        αright = rand(len) .+ 1
+        αleft = rand(rng, len) .+ 1
+        αright = rand(rng, len) .+ 1
         @testset let (left, right) = (Dirichlet(αleft), Dirichlet(αright))
             @test test_generic_simple_exponentialfamily_product(
                 left,

--- a/test/distributions/dirichlet_tests.jl
+++ b/test/distributions/dirichlet_tests.jl
@@ -32,7 +32,7 @@ end
     include("distributions_setuptests.jl")
 
     for len in 3:5
-        α = rand(len)
+        α = rand(StableRNG(42), len)
         @testset let d = Dirichlet(α)
             ef = test_exponentialfamily_interface(d; option_assume_no_allocations = false)
             η1 = getnaturalparameters(ef)

--- a/test/distributions/wishart_inverse_tests.jl
+++ b/test/distributions/wishart_inverse_tests.jl
@@ -17,7 +17,9 @@ end
 
     import ExponentialFamily: InverseWishartFast
 
-    @testset for dim in (3), S in rand(InverseWishart(10, Array(Eye(dim))), 2)
+    rng = StableRNG(42)
+
+    @testset for dim in (3), S in rand(rng, InverseWishart(10, Array(Eye(dim))), 2)
         ν = dim + 4
         @testset let (d = InverseWishartFast(ν, S))
             ef = test_exponentialfamily_interface(d; option_assume_no_allocations = false, test_fisherinformation_against_hessian = false)

--- a/test/distributions/wishart_tests.jl
+++ b/test/distributions/wishart_tests.jl
@@ -44,9 +44,11 @@ end
 
     import ExponentialFamily: WishartFast
 
+    rng = StableRNG(42)
+
     for d in (2, 3, 4, 5)
-        v = rand() + d
-        L = rand(d, d)
+        v = rand(rng) + d
+        L = rand(rng, d, d)
         S = L' * L + d * Eye(d)
         invS = inv(S)
         cS = copy(S)
@@ -74,7 +76,9 @@ end
 
     import ExponentialFamily: WishartFast
 
-    for dim in (3, 4), invS in rand(Wishart(10, Array(Eye(dim))), 2)
+    rng = StableRNG(42)
+
+    for dim in (3, 4), invS in rand(rng, Wishart(10, Array(Eye(dim))), 2)
         ν = dim + 2
         @testset let (d = WishartFast(ν, invS))
             ef = test_exponentialfamily_interface(d; option_assume_no_allocations = false, test_fisherinformation_against_hessian = false)


### PR DESCRIPTION
This PR aims to fix https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/195.

Chi-squared distribution is actually has the same density as $\mathcal{G}(\frac{\nu}{2}, 2)$. So the nature parameter can be easily extended to any number greater then -1. 