### PR TITLE
fix-rand-matrixDirichlet

### DIFF
--- a/src/distributions/matrix_dirichlet.jl
+++ b/src/distributions/matrix_dirichlet.jl
@@ -75,7 +75,7 @@ end
 
 function BayesBase.rand!(rng::AbstractRNG, dist::MatrixDirichlet, container::AbstractMatrix{T}) where {T <: Real}
     samples = vmap(d -> rand(rng, Dirichlet(convert(Vector, d))), eachcol(dist.a))
-    @views for row in 1:size(container,2)
+    @views for row in 1:size(container, 2)
         b = container[:, row]
         b[:] .= samples[row]
     end

--- a/src/distributions/matrix_dirichlet.jl
+++ b/src/distributions/matrix_dirichlet.jl
@@ -74,12 +74,9 @@ function BayesBase.rand(rng::AbstractRNG, dist::MatrixDirichlet{T}, nsamples::In
 end
 
 function BayesBase.rand!(rng::AbstractRNG, dist::MatrixDirichlet, container::AbstractMatrix{T}) where {T <: Real}
-    samples = vmap(d -> rand(rng, Dirichlet(convert(Vector, d))), eachcol(dist.a))
-    @views for row in 1:size(container, 2)
-        b = container[:, row]
-        b[:] .= samples[row]
+    @views for (i, col) in enumerate(eachcol(dist.a))
+        rand!(rng, Dirichlet(col), container[:, i])
     end
-
     return container
 end
 

--- a/src/distributions/matrix_dirichlet.jl
+++ b/src/distributions/matrix_dirichlet.jl
@@ -75,7 +75,7 @@ end
 
 function BayesBase.rand!(rng::AbstractRNG, dist::MatrixDirichlet, container::AbstractMatrix{T}) where {T <: Real}
     samples = vmap(d -> rand(rng, Dirichlet(convert(Vector, d))), eachcol(dist.a))
-    @views for row in 1:isqrt(length(container))
+    @views for row in 1:size(container,2)
         b = container[:, row]
         b[:] .= samples[row]
     end

--- a/test/distributions/matrix_dirichlet_tests.jl
+++ b/test/distributions/matrix_dirichlet_tests.jl
@@ -148,3 +148,13 @@ end
     @test promote_variate_type(Multivariate, MatrixDirichlet) === Dirichlet
     @test promote_variate_type(Matrixvariate, MatrixDirichlet) === MatrixDirichlet
 end
+
+@testitem "MatrixDirichlet: rand" begin
+    include("distributions_setuptests.jl")
+
+    @test_throws DimensionMismatch sum(rand(MatrixDirichlet(ones(3, 5))), dims = 1) ≈ [1.0;; 1.0;; 1.0]
+
+    @test sum(rand(MatrixDirichlet(ones(3, 5))), dims = 1) ≈ [1.0;; 1.0;; 1.0;; 1.0;; 1.0]
+    @test sum(rand(MatrixDirichlet(ones(5, 3))), dims = 1) ≈ [1.0;; 1.0;; 1.0]
+    @test sum(rand(MatrixDirichlet(ones(5, 5))), dims = 1) ≈ [1.0;; 1.0;; 1.0;; 1.0;; 1.0]
+end


### PR DESCRIPTION
Fix [bug](https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/210) 

Previous was working only for squared matrix.
Now iterate over the number of columns to generate Dirichlet data.
