### PR TITLE
Fix bug on `isproper `of MatrixDirichlet

### DIFF
--- a/src/distributions/matrix_dirichlet.jl
+++ b/src/distributions/matrix_dirichlet.jl
@@ -116,9 +116,9 @@ end
 # Natural parametrization
 
 isproper(::NaturalParametersSpace, ::Type{MatrixDirichlet}, η, conditioner) =
-    isnothing(conditioner) && length(η) > 1 && typeof(isqrt(length(η))) <: Integer && all(isless.(-1, η)) && all(!isinf, η) && all(!isnan, η)
+    isnothing(conditioner) && length(η) > 1 && all(isless.(-1, η)) && all(!isinf, η) && all(!isnan, η)
 isproper(::MeanParametersSpace, ::Type{MatrixDirichlet}, θ, conditioner) =
-    isnothing(conditioner) && length(θ) > 1 && typeof(isqrt(length(θ))) <: Integer && all(>(0), θ) && all(!isinf, θ) && all(!isnan, θ)
+    isnothing(conditioner) && length(θ) > 1 &&all(>(0), θ) && all(!isinf, θ) && all(!isnan, θ)
 
 function (::MeanToNatural{MatrixDirichlet})(tuple_of_θ::Tuple{Any})
     (α,) = tuple_of_θ

--- a/test/distributions/matrix_dirichlet_tests.jl
+++ b/test/distributions/matrix_dirichlet_tests.jl
@@ -90,15 +90,14 @@ end
     end
 
     for space in (MeanParametersSpace(), NaturalParametersSpace())
-        @test !isproper(space, MatrixDirichlet, [Inf Inf; Inf 1.0], 1.0)
+        @test !isproper(space, MatrixDirichlet, [Inf Inf; Inf 1.0])
         @test !isproper(space, MatrixDirichlet, [1.0], Inf)
-        @test !isproper(space, MatrixDirichlet, [NaN], 1.0)
+        @test !isproper(space, MatrixDirichlet, [NaN],)
         @test !isproper(space, MatrixDirichlet, [1.0], NaN)
         @test !isproper(space, MatrixDirichlet, [0.5, 0.5], 1.0)
         @test isproper(space, MatrixDirichlet, [2.0, 3.0])
         @test !isproper(space, MatrixDirichlet, [-1.0, -1.2])
-    end
-
+    end 
     @test_throws Exception convert(ExponentialFamilyDistribution, MatrixDirichlet([Inf Inf; 2 3]))
 end
 


### PR DESCRIPTION
- Most of the tests were actually testing nothing because the first assertion of the `isproper` function was to test the absence of the last argument in the call and most of the test had a last argument
- The function `isproper` itself had an assertion that was always true independently of the input of MatrixDirichlet

close https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/213 
