### PR TITLE
Vector with NaN is improper Dirichlet in natural parameters

### DIFF
--- a/src/distributions/dirichlet.jl
+++ b/src/distributions/dirichlet.jl
@@ -35,7 +35,8 @@ function BayesBase.insupport(ef::ExponentialFamilyDistribution{Dirichlet}, x)
 end
 # Natural parametrization
 
-isproper(::NaturalParametersSpace, ::Type{Dirichlet}, η, conditioner) = isnothing(conditioner) && length(η) > 1 && all(isless.(-1, η)) && all(!isinf, η)
+isproper(::NaturalParametersSpace, ::Type{Dirichlet}, η, conditioner) =
+    isnothing(conditioner) && length(η) > 1 && all(isless.(-1, η)) && all(!isinf, η) && all(!isnan, η)
 isproper(::MeanParametersSpace, ::Type{Dirichlet}, θ, conditioner) = isnothing(conditioner) && length(θ) > 1 && all(>(0), θ) && all(!isinf, θ)
 
 function (::MeanToNatural{Dirichlet})(tuple_of_θ::Tuple{Any})

--- a/test/distributions/dirichlet_tests.jl
+++ b/test/distributions/dirichlet_tests.jl
@@ -58,6 +58,7 @@ end
         @test !isproper(space, Dirichlet, [0.5, 0.5], 1.0)
         @test isproper(space, Dirichlet, [2.0, 3.0])
         @test !isproper(space, Dirichlet, [-1.0, -1.2])
+        @test !isproper(space, Dirichlet, [NaN, 1.0, 1.0])
     end
 
     @test_throws Exception convert(ExponentialFamilyDistribution, Dirichlet([Inf, Inf]))


### PR DESCRIPTION
For some reason (because `isless(-1, NaN)` returns `true`), a vector of `[Nan, 1.0]` was regarded as a proper natural parameter for a `Dirichlet` distribution. This PR fixes that bug