### PR TITLE
Promote array types for DirichletCollection

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,11 +28,11 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
@@ -47,8 +47,8 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
-      - uses: actions/cache@v1
+      - uses: julia-actions/setup-julia@v2
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -59,8 +59,6 @@ jobs:
             ${{ runner.os }}-docs-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest          
-        with:
-          version: '1.10'
       - run: make docs
         env:
           PYTHON: ""

--- a/src/distributions/dirichlet_collection.jl
+++ b/src/distributions/dirichlet_collection.jl
@@ -34,7 +34,11 @@ struct DirichletCollection{T <: Real, N, A <: AbstractArray{T, N}} <: Distributi
         end
         alpha0 = sum(alpha; dims = 1)
         lmnB = sum(loggamma, alpha; dims = 1) - loggamma.(alpha0)
-        new{T, N, typeof(alpha)}(alpha, alpha0, lmnB)
+        NT = promote_type(T, eltype(alpha0), eltype(lmnB))
+        alpha = convert_paramfloattype(NT, alpha)
+        alpha0 = convert_paramfloattype(NT, alpha0)
+        lmnB = convert_paramfloattype(NT, lmnB)
+        new{NT, N, typeof(alpha)}(alpha, alpha0, lmnB)
     end
 end
 

--- a/test/distributions/dirichlet_collection_test.jl
+++ b/test/distributions/dirichlet_collection_test.jl
@@ -11,6 +11,9 @@
         @test variate_form(DirichletCollection{Float64, N, Array{Float64, N}}) === ArrayLikeVariate{N}
     end
 
+    @test DirichletCollection(rand(3, 3, 3)) isa DirichletCollection{Float64, 3, Array{Float64, 3}}
+    @test DirichletCollection(rand(1:10, 3, 3, 3)) isa DirichletCollection{Float64, 3, Array{Float64, 3}}
+
     @test_throws "ArgumentError: All elements of the alpha tensor should be positive" DirichletCollection(zeros(3, 3, 3))
 end
 


### PR DESCRIPTION
The problem was when we create a DirichletCollection with `Int64` entries we couldn't create `lmnB` as a tensor of integers. this PR promotes the tensors to be of the same type such that we can always create a `DirichletCollection`.