### PR TITLE
make prod faster for categorical

### DIFF
--- a/src/distributions/categorical.jl
+++ b/src/distributions/categorical.jl
@@ -13,8 +13,8 @@ BayesBase.default_prod_rule(::Type{<:Categorical}, ::Type{<:Categorical}) = Pres
 
 function BayesBase.prod(::PreserveTypeProd{Distribution}, left::Categorical, right::Categorical)
     mvec = clamp.(probvec(left) .* probvec(right), tiny, huge)
-    norm = sum(mvec)
-    return Categorical(mvec ./ norm)
+    mvec ./= sum(mvec)
+    return Categorical(mvec; check_args = false)
 end
 
 BayesBase.probvec(dist::Categorical) = probs(dist)


### PR DESCRIPTION
Multiplying 2 10-dimensional Categoricals. Before:
```
BenchmarkTools.Trial: 10000 samples with 937 evaluations per sample.
 Range (min … max):  104.856 ns …  2.761 μs  ┊ GC (min … max): 0.00% … 94.00%
 Time  (median):     110.726 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   122.720 ns ± 83.189 ns  ┊ GC (mean ± σ):  9.21% ± 11.80%

  █▄                                                           ▁
  ████▇▅▄▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▇█▄▄▄▅▄▄▃▄▁▁▃▁▄▃▁▁▃▃▁▁▁▄▅▁▁▄▄▅▅▄▄▅▅▄▅ █
  105 ns        Histogram: log(frequency) by time       663 ns <

 Memory estimate: 432 bytes, allocs estimate: 6.
 ```
 After:
 ```
 BenchmarkTools.Trial: 10000 samples with 988 evaluations per sample.
 Range (min … max):  41.666 ns …   5.902 μs  ┊ GC (min … max): 0.00% … 98.57%
 Time  (median):     48.583 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   54.641 ns ± 118.446 ns  ┊ GC (mean ± σ):  8.90% ±  5.50%

                  █▁▅▂                                          
  ▂▁▁▁▁▁▁▁▂▁▁▁▂▁▃▅█████▇▇▇▅▄▄▃▃▃▃▃▃▃▃▃▃▄▃▄▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  41.7 ns         Histogram: frequency by time         61.9 ns <

 Memory estimate: 144 bytes, allocs estimate: 2.
 ```
 
 Because of stupid check_args and in-place normalization.