### PR TITLE
Add constructor for mixed precision MvNormalWishart

### DIFF
--- a/src/distributions/mv_normal_wishart.jl
+++ b/src/distributions/mv_normal_wishart.jl
@@ -29,6 +29,18 @@ struct MvNormalWishart{T, M <: AbstractArray{T}, V <: AbstractMatrix{T}, K <: Re
     ) where {T, M <: AbstractArray{T}, V <: AbstractMatrix{T}, K <: Real, N <: Real}
         new{T, M, V, K, N}(μ, Ψ, κ, ν)
     end
+
+    function MvNormalWishart(
+        μ::M,
+        Ψ::V,
+        κ::K,
+        ν::N
+    ) where {T1, T2, M <: AbstractArray{T1}, V <: AbstractMatrix{T2}, K <: Real, N <: Real}
+        T = promote_type(T1, T2)
+        μ_new = convert(AbstractArray{T}, μ)
+        Ψ_new = convert(AbstractMatrix{T}, Ψ)
+        return new{T, typeof(μ_new), typeof(Ψ_new), K, N}(μ_new, Ψ_new, κ, ν)
+    end
 end
 
 scatter(d::MvNormalWishart) = getindex(params(d), 2)

--- a/test/distributions/mv_normal_wishart_tests.jl
+++ b/test/distributions/mv_normal_wishart_tests.jl
@@ -11,6 +11,20 @@
     @test locationdim(dist) == 2
 end
 
+@testitem "MvNormalWishart: construction with mixed precision" begin
+    include("distributions_setuptests.jl")
+
+    m = rand(Float32, 2)
+    Ψ = [1.0 0.0; 0.0 1.0]
+    dist = MvNormalWishart(m, Ψ, 0.1, 3.0)
+    @test paramfloattype(dist) == Float64
+
+    m = rand(Float32, 2)
+    Ψ = [1.0f0 0.0f0; 0.0f0 1.0f0]
+    dist = MvNormalWishart(m, Ψ, 0.1f0, 3.0f0)
+    @test paramfloattype(dist) == Float32
+end
+
 @testitem "MvNormalWishart: ExponentialFamilyDistribution" begin
     include("distributions_setuptests.jl")
 


### PR DESCRIPTION
Fixes @esther-van-pelt 's issue where MvNormalWishart could not get constructed because of mixed precision inputs for mean vector and scale matrix