### PR TITLE
Added MvNormalGamma distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to ExponentialFamily.jl will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `MvNormalGamma` distribution — the multivariate generalization of `NormalGamma`, i.e. the joint conjugate prior over a Gaussian mean vector `θ` and a scalar precision `γ` (`θ ∣ γ ~ N(μ, (γΛ)⁻¹)`, `γ ~ Gamma(α, β)`). Includes the full `ExponentialFamily` interface (natural parameters, log-partition, gradient, Fisher information), `prod`, sampling, `logpdf`, and differential `entropy` ([#287](https://github.com/ReactiveBayes/ExponentialFamily.jl/pull/287)).

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -20,6 +20,7 @@ ExponentialFamily.JointGaussian
 ExponentialFamily.WishartFast
 ExponentialFamily.InverseWishartFast
 ExponentialFamily.NormalGamma
+ExponentialFamily.MvNormalGamma
 ExponentialFamily.MvNormalWishart
 ExponentialFamily.MatrixNormalWishart
 ExponentialFamily.DirichletCollection

--- a/src/ExponentialFamily.jl
+++ b/src/ExponentialFamily.jl
@@ -76,5 +76,6 @@ include("distributions/chi_squared.jl")
 include("distributions/matrix_normal_wishart.jl")
 include("distributions/mv_normal_wishart.jl")
 include("distributions/normal_gamma.jl")
+include("distributions/mv_normal_gamma.jl")
 
 end

--- a/src/distributions/mv_normal_gamma.jl
+++ b/src/distributions/mv_normal_gamma.jl
@@ -69,18 +69,18 @@ Base.length(d::MvNormalGamma) = length(d.μ) + 1
 Base.size(d::MvNormalGamma) = (length(d),)
 
 function BayesBase.var(d::MvNormalGamma)
-    d.α > one(d.α) || error("`var` of `MvNormalGamma` is not defined for `α < 1`")
+    d.α > one(d.α) || error("`var` of `MvNormalGamma` is not defined for `α ≤ 1`")
     # Marginal covariance of x is (β / (α-1)) Λ⁻¹ ; variance of τ is α/β²
     return (d.β / (d.α - one(d.α)) * cholinv(d.Λ), d.α / (d.β^2))
 end
 
 function BayesBase.cov(d::MvNormalGamma)
-    d.α > one(d.α) || error("`cov` of `MvNormalGamma` is not defined for `α < 1`")
+    d.α > one(d.α) || error("`cov` of `MvNormalGamma` is not defined for `α ≤ 1`")
     return var(d)
 end
 
 function BayesBase.std(d::MvNormalGamma)
-    d.α > one(d.α) || error("`std` of `MvNormalGamma` is not defined for `α < 1`")
+    d.α > one(d.α) || error("`std` of `MvNormalGamma` is not defined for `α ≤ 1`")
     cx, vτ = var(d)
     # Per-component standard deviations of `x` (sqrt of the marginal variances) and of `τ`.
     return (sqrt.(diag(cx)), sqrt(vτ))
@@ -106,7 +106,7 @@ function BayesBase.logpdf(dist::MvNormalGamma, x::AbstractVector{<:Real})
 
     constants = α * log(β) + (1 / 2) * logdet(Λ) - loggamma(α) - (d / 2) * log(twoπ)
     term1 = (α + d / 2 - 1) * log(τ) - β * τ
-    term2 = -τ * dot(diff, Λ, diff) / 2
+    term2 = -τ * dot3arg(diff, Λ, diff) / 2
 
     return constants + term1 + term2
 end
@@ -158,8 +158,8 @@ function BayesBase.prod(::PreserveTypeProd{Distribution}, left::MvNormalGamma, r
     # (reduces to the scalar `NormalGamma` rule αˡ + αʳ − 1/2 when d = 1).
     α = αleft + αright + d / 2 - 1
     β =
-        βleft + βright + dot(μleft, Λleft, μleft) / 2 + dot(μright, Λright, μright) / 2 -
-        dot(μ, Λ, μ) / 2
+        βleft + βright + dot3arg(μleft, Λleft, μleft) / 2 + dot3arg(μright, Λright, μright) / 2 -
+        dot3arg(μ, Λ, μ) / 2
 
     return MvNormalGamma(μ, Λ, α, β)
 end
@@ -170,6 +170,15 @@ Base.eltype(::MvNormalGammaDomain) = AbstractVector
 Base.in(v, ::MvNormalGammaDomain) = length(v) >= 2 && all(isreal, v) && v[end] > 0
 
 BayesBase.support(::Type{MvNormalGamma}) = MvNormalGammaDomain()
+
+# The domain check above is dimension-agnostic. For a concrete exponential-family member we also
+# know the location dimension `d` (from the packed natural parameters of length `d² + d + 2`), so
+# a valid sample must be a `(d + 1)`-vector `[x₁, …, x_d, τ]` with `τ > 0`. Enforcing the exact
+# length here prevents out-of-bounds reads in `logpdf`/sufficient statistics for wrong-sized inputs.
+function BayesBase.insupport(ef::ExponentialFamilyDistribution{MvNormalGamma}, x)
+    d = _mvng_dim(length(getnaturalparameters(ef)))
+    return length(x) == d + 1 && all(isreal, x) && x[end] > 0
+end
 
 # Natural parametrization
 function isproper(::NaturalParametersSpace, ::Type{MvNormalGamma}, η, conditioner)
@@ -183,7 +192,7 @@ function isproper(::NaturalParametersSpace, ::Type{MvNormalGamma}, η, condition
     Λ = -2 * η2
     isposdef(Λ) || return false
     α = η3 - d / 2 + 1
-    β = -η4 - dot(η1, cholinv(Λ), η1) / 2
+    β = -η4 - dot3arg(η1, cholinv(Λ), η1) / 2
     return α > 0 && β > 0
 end
 
@@ -204,7 +213,7 @@ function (::MeanToNatural{MvNormalGamma})(tuple_of_θ::Tuple{Any, Any, Any, Any}
     η1 = Λ * μ
     η2 = -Λ / 2
     η3 = α + d / 2 - 1
-    η4 = -β - dot(μ, Λ, μ) / 2
+    η4 = -β - dot3arg(μ, Λ, μ) / 2
     return (η1, η2, η3, η4)
 end
 
@@ -215,7 +224,7 @@ function (::NaturalToMean{MvNormalGamma})(tuple_of_η::Tuple{Any, Any, Any, Any}
     Λinv = cholinv(Λ)
     μ = Λinv * η1
     α = η3 - d / 2 + 1
-    β = -η4 - dot(η1, Λinv, η1) / 2
+    β = -η4 - dot3arg(η1, Λinv, η1) / 2
     return (μ, Λ, α, β)
 end
 
@@ -252,7 +261,7 @@ getlogpartition(::NaturalParametersSpace, ::Type{MvNormalGamma}) = (η) -> begin
     d = length(η1)
     Λ = -2 * η2
     α = η3 - d / 2 + 1
-    β = -η4 - dot(η1, cholinv(Λ), η1) / 2
+    β = -η4 - dot3arg(η1, cholinv(Λ), η1) / 2
     return loggamma(α) - α * log(β) - (1 / 2) * logdet(Λ)
 end
 
@@ -263,7 +272,7 @@ getgradlogpartition(::NaturalParametersSpace, ::Type{MvNormalGamma}) = (η) -> b
     Λinv = cholinv(Λ)
     μ = Λinv * η1
     α = η3 - d / 2 + 1
-    β = -η4 - dot(η1, Λinv, η1) / 2
+    β = -η4 - dot3arg(η1, Λinv, η1) / 2
 
     # The gradient of the log-partition equals E[T(x,τ)]:
     #   E[τx]    = μ ⋅ α/β
@@ -296,7 +305,7 @@ getfisherinformation(::NaturalParametersSpace, ::Type{MvNormalGamma}) = (η) -> 
     W = cholinv(Λ)
     μ = W * η1
     α = η3 - d / 2 + 1
-    β = -η4 - dot(η1, W, η1) / 2
+    β = -η4 - dot3arg(η1, W, η1) / 2
 
     J = _mvng_natural_to_mean_jacobian(μ, W, d, eltype(η))
     Fθ = _mvng_fisher_mean(Λ, W, α, β, d, eltype(η))

--- a/src/distributions/mv_normal_gamma.jl
+++ b/src/distributions/mv_normal_gamma.jl
@@ -1,0 +1,354 @@
+export MvNormalGamma
+using Distributions
+import StatsFuns: loggamma
+using Random
+using LinearAlgebra
+using DomainSets
+
+"""
+    MvNormalGamma{T, M <: AbstractVector{T}, L <: AbstractMatrix{T}, A <: Real, B <: Real} <: ContinuousMultivariateDistribution
+
+A multivariate normal-gamma distribution. This is the joint distribution of a multivariate
+normal random vector `x` with mean `μ` and precision `τΛ`, and a gamma-distributed scalar
+precision `τ` with shape `α` and rate `β`:
+
+```
+p(x, τ) = N(x | μ, (τΛ)⁻¹) ⋅ Gamma(τ | α, β)
+```
+
+It is the multivariate generalization of [`NormalGamma`](@ref): the scalar precision-scaling
+`λ` becomes a `d × d` positive-definite precision-structure matrix `Λ`. Setting `d = 1`
+recovers `NormalGamma` exactly.
+
+# Fields
+- `μ::M`: The mean vector of the multivariate normal distribution.
+- `Λ::L`: The precision-structure matrix of the multivariate normal distribution (positive-definite).
+- `α::A`: The shape parameter of the gamma distribution.
+- `β::B`: The rate parameter of the gamma distribution.
+"""
+struct MvNormalGamma{T, M <: AbstractVector{T}, L <: AbstractMatrix{T}, A <: Real, B <: Real} <:
+       ContinuousMultivariateDistribution
+    μ::M
+    Λ::L
+    α::A
+    β::B
+
+    function MvNormalGamma(
+        μ::M,
+        Λ::L,
+        α::A,
+        β::B
+    ) where {T, M <: AbstractVector{T}, L <: AbstractMatrix{T}, A <: Real, B <: Real}
+        new{T, M, L, A, B}(μ, Λ, α, β)
+    end
+
+    function MvNormalGamma(
+        μ::M,
+        Λ::L,
+        α::A,
+        β::B
+    ) where {T1, T2, M <: AbstractVector{T1}, L <: AbstractMatrix{T2}, A <: Real, B <: Real}
+        T = promote_type(T1, T2)
+        μ_new = convert(AbstractVector{T}, μ)
+        Λ_new = convert(AbstractMatrix{T}, Λ)
+        return new{T, typeof(μ_new), typeof(Λ_new), A, B}(μ_new, Λ_new, α, β)
+    end
+end
+
+BayesBase.params(d::MvNormalGamma)   = (d.μ, d.Λ, d.α, d.β)
+BayesBase.location(d::MvNormalGamma) = first(params(d))
+BayesBase.scale(d::MvNormalGamma)    = getindex(params(d), 2)
+BayesBase.shape(d::MvNormalGamma)    = getindex(params(d), 3)
+BayesBase.rate(d::MvNormalGamma)     = getindex(params(d), 4)
+
+# Joint mean: (E[x], E[τ]) = (μ, α/β)
+BayesBase.mean(d::MvNormalGamma) = (d.μ, d.α / d.β)
+
+Base.eltype(::MvNormalGamma{T}) where {T} = T
+Base.length(d::MvNormalGamma)  = length(d.μ) + 1
+Base.size(d::MvNormalGamma)    = (length(d),)
+
+function BayesBase.var(d::MvNormalGamma)
+    d.α > one(d.α) || error("`var` of `MvNormalGamma` is not defined for `α < 1`")
+    # Marginal covariance of x is (β / (α-1)) Λ⁻¹ ; variance of τ is α/β²
+    return (d.β / (d.α - one(d.α)) * cholinv(d.Λ), d.α / (d.β^2))
+end
+
+function BayesBase.cov(d::MvNormalGamma)
+    d.α > one(d.α) || error("`cov` of `MvNormalGamma` is not defined for `α < 1`")
+    return var(d)
+end
+
+function BayesBase.std(d::MvNormalGamma)
+    d.α > one(d.α) || error("`std` of `MvNormalGamma` is not defined for `α < 1`")
+    cx, vτ = var(d)
+    # Per-component standard deviations of `x` (sqrt of the marginal variances) and of `τ`.
+    return (sqrt.(diag(cx)), sqrt(vτ))
+end
+
+# A sample is packed as a vector `[x₁, …, x_d, τ]`: the first `d` entries are the mean
+# components and the last entry is the precision `τ`.
+function BayesBase.logpdf(dist::MvNormalGamma, x::AbstractVector{<:Real})
+    (μ, Λ, α, β) = params(dist)
+    d = length(μ)
+    xμ = view(x, 1:d)
+    τ = x[d+1]
+    diff = xμ - μ
+
+    constants = α * log(β) + (1 / 2) * logdet(Λ) - loggamma(α) - (d / 2) * log(twoπ)
+    term1 = (α + d / 2 - 1) * log(τ) - β * τ
+    term2 = -τ * dot(diff, Λ, diff) / 2
+
+    return constants + term1 + term2
+end
+
+BayesBase.pdf(dist::MvNormalGamma, x::AbstractVector{<:Real}) = exp(logpdf(dist, x))
+
+function BayesBase.rand!(rng::AbstractRNG, dist::MvNormalGamma, container::AbstractVector)
+    (μ, Λ, α, β) = params(dist)
+    d = length(μ)
+    τ = rand(rng, GammaShapeRate(α, β))
+    container[d+1] = τ
+    container[1:d] = rand(rng, MvNormalMeanPrecision(μ, τ * Λ))
+    return container
+end
+
+function BayesBase.rand!(rng::AbstractRNG, dist::MvNormalGamma, container::AbstractVector{T}) where {T <: Vector}
+    for i in eachindex(container)
+        rand!(rng, dist, container[i])
+    end
+    return container
+end
+
+function BayesBase.rand(rng::AbstractRNG, dist::MvNormalGamma)
+    container = Vector{Float64}(undef, length(dist.μ) + 1)
+    rand!(rng, dist, container)
+    return container
+end
+
+function BayesBase.rand(rng::AbstractRNG, dist::MvNormalGamma, nsamples::Int)
+    container = Vector{Vector{Float64}}(undef, nsamples)
+    d = length(dist.μ)
+    for i in eachindex(container)
+        container[i] = Vector{Float64}(undef, d + 1)
+        rand!(rng, dist, container[i])
+    end
+    return container
+end
+
+BayesBase.default_prod_rule(::Type{<:MvNormalGamma}, ::Type{<:MvNormalGamma}) = PreserveTypeProd(Distribution)
+
+function BayesBase.prod(::PreserveTypeProd{Distribution}, left::MvNormalGamma, right::MvNormalGamma)
+    (μleft, Λleft, αleft, βleft) = params(left)
+    (μright, Λright, αright, βright) = params(right)
+    d = length(μleft)
+
+    Λ = Λleft + Λright
+    μ = cholinv(Λ) * (Λleft * μleft + Λright * μright)
+    # Natural parameters add under multiplication; mapping back gives α = αˡ + αʳ + d/2 − 1
+    # (reduces to the scalar `NormalGamma` rule αˡ + αʳ − 1/2 when d = 1).
+    α = αleft + αright + d / 2 - 1
+    β =
+        βleft + βright + dot(μleft, Λleft, μleft) / 2 + dot(μright, Λright, μright) / 2 -
+        dot(μ, Λ, μ) / 2
+
+    return MvNormalGamma(μ, Λ, α, β)
+end
+
+struct MvNormalGammaDomain <: Domain{AbstractVector} end
+
+Base.eltype(::MvNormalGammaDomain) = AbstractVector
+Base.in(v, ::MvNormalGammaDomain) = length(v) >= 2 && all(isreal, v) && v[end] > 0
+
+BayesBase.support(::Type{MvNormalGamma}) = MvNormalGammaDomain()
+
+# Natural parametrization
+function isproper(::NaturalParametersSpace, ::Type{MvNormalGamma}, η, conditioner)
+    isnothing(conditioner) || return false
+    (any(isnan, η) || any(isinf, η)) && return false
+    len = length(η)
+    d = _mvng_dim(len)
+    (d < 1 || d^2 + d + 2 != len) && return false
+
+    (η1, η2, η3, η4) = unpack_parameters(MvNormalGamma, η)
+    Λ = -2 * η2
+    isposdef(Λ) || return false
+    α = η3 - d / 2 + 1
+    β = -η4 - dot(η1, cholinv(Λ), η1) / 2
+    return α > 0 && β > 0
+end
+
+function isproper(::DefaultParametersSpace, ::Type{MvNormalGamma}, θ, conditioner)
+    isnothing(conditioner) || return false
+    (any(isnan, θ) || any(isinf, θ)) && return false
+    len = length(θ)
+    d = _mvng_dim(len)
+    (d < 1 || d^2 + d + 2 != len) && return false
+
+    (_, Λ, α, β) = unpack_parameters(MvNormalGamma, θ)
+    return isposdef(Λ) && α > 0 && β > 0
+end
+
+function (::MeanToNatural{MvNormalGamma})(tuple_of_θ::Tuple{Any, Any, Any, Any})
+    (μ, Λ, α, β) = tuple_of_θ
+    d = length(μ)
+    η1 = Λ * μ
+    η2 = -Λ / 2
+    η3 = α + d / 2 - 1
+    η4 = -β - dot(μ, Λ, μ) / 2
+    return (η1, η2, η3, η4)
+end
+
+function (::NaturalToMean{MvNormalGamma})(tuple_of_η::Tuple{Any, Any, Any, Any})
+    (η1, η2, η3, η4) = tuple_of_η
+    d = length(η1)
+    Λ = -2 * η2
+    Λinv = cholinv(Λ)
+    μ = Λinv * η1
+    α = η3 - d / 2 + 1
+    β = -η4 - dot(η1, Λinv, η1) / 2
+    return (μ, Λ, α, β)
+end
+
+# Recover the location dimension `d` from a packed parameter vector of length `d² + d + 2`.
+_mvng_dim(len) = Int64((-1 + isqrt(1 - 4 * (2 - len))) / 2)
+
+function unpack_parameters(::Type{MvNormalGamma}, packed)
+    len = length(packed)
+    d = _mvng_dim(len)
+
+    @inbounds η1 = view(packed, 1:d)
+    @inbounds η2 = reshape(view(packed, (d+1):(d^2+d)), d, d)
+    @inbounds η3 = packed[d^2+d+1]
+    @inbounds η4 = packed[d^2+d+2]
+
+    return (η1, η2, η3, η4)
+end
+
+isbasemeasureconstant(::Type{MvNormalGamma}) = ConstantBaseMeasure()
+
+# Base measure (2π)^(-d/2), where d = length(x) - 1.
+getbasemeasure(::Type{MvNormalGamma}) = (x) -> (twoπ)^(-(length(x) - 1) / 2)
+
+# x is a (d+1)-vector: first d entries are the mean, last entry is the precision τ.
+getsufficientstatistics(::Type{MvNormalGamma}) = (
+    x -> x[end] * view(x, 1:(length(x)-1)),
+    x -> x[end] * (view(x, 1:(length(x)-1)) * view(x, 1:(length(x)-1))'),
+    x -> log(x[end]),
+    x -> x[end]
+)
+
+getlogpartition(::NaturalParametersSpace, ::Type{MvNormalGamma}) = (η) -> begin
+    (η1, η2, η3, η4) = unpack_parameters(MvNormalGamma, η)
+    d = length(η1)
+    Λ = -2 * η2
+    α = η3 - d / 2 + 1
+    β = -η4 - dot(η1, cholinv(Λ), η1) / 2
+    return loggamma(α) - α * log(β) - (1 / 2) * logdet(Λ)
+end
+
+getgradlogpartition(::NaturalParametersSpace, ::Type{MvNormalGamma}) = (η) -> begin
+    (η1, η2, η3, η4) = unpack_parameters(MvNormalGamma, η)
+    d = length(η1)
+    Λ = -2 * η2
+    Λinv = cholinv(Λ)
+    μ = Λinv * η1
+    α = η3 - d / 2 + 1
+    β = -η4 - dot(η1, Λinv, η1) / 2
+
+    # The gradient of the log-partition equals E[T(x,τ)]:
+    #   E[τx]    = μ ⋅ α/β
+    #   E[τxxᵀ]  = Λ⁻¹ + (α/β) μμᵀ
+    #   E[log τ] = digamma(α) - log β
+    #   E[τ]     = α/β
+    dη1 = (α / β) * μ
+    dη2 = Λinv + (α / β) * (μ * μ')
+    dη3 = SpecialFunctions.digamma(α) - log(β)
+    dη4 = α / β
+
+    return vcat(dη1, vec(dη2), dη3, dη4)
+end
+
+# Fisher information in the natural parameter space.
+#
+# Because `η₂` is stored as a full `d × d` matrix while the family only depends on its
+# symmetric part, the literal Hessian of the log-partition w.r.t. the free entries does not
+# match `ForwardDiff` (which also sees the antisymmetric directions), and the textbook
+# `Cov(T)` is rank-deficient (the sufficient statistic `τxxᵀ` is symmetric). The same issue
+# applies to `MvNormalWishart`, which is why the Fisher-against-Hessian/Jacobian checks are
+# disabled there too. We therefore build a full-rank, symmetric, positive-definite Fisher via
+# the exact metric transform `Fη = Jᵀ Fθ J`, where `J = ∂θ/∂η` is the Jacobian of
+# `NaturalToMean` and `Fθ` is the mean-space Fisher below. This reduces exactly to the scalar
+# `NormalGamma` Fisher when `d = 1`.
+getfisherinformation(::NaturalParametersSpace, ::Type{MvNormalGamma}) = (η) -> begin
+    (η1, η2, η3, η4) = unpack_parameters(MvNormalGamma, η)
+    d = length(η1)
+    Λ = -2 * η2
+    W = cholinv(Λ)
+    μ = W * η1
+    α = η3 - d / 2 + 1
+    β = -η4 - dot(η1, W, η1) / 2
+
+    J = _mvng_natural_to_mean_jacobian(μ, W, d, eltype(η))
+    Fθ = _mvng_fisher_mean(Λ, W, α, β, d, eltype(η))
+    return J' * Fθ * J
+end
+
+getfisherinformation(::DefaultParametersSpace, ::Type{MvNormalGamma}) = (θ) -> begin
+    (μ, Λ, α, β) = unpack_parameters(MvNormalGamma, θ)
+    d = length(μ)
+    W = cholinv(Λ)
+    return _mvng_fisher_mean(Λ, W, α, β, d, eltype(θ))
+end
+
+# Mean-space Fisher information. The block for `μ` decouples from the rest (third central
+# Gaussian moments vanish); the `Λ` block uses the full-rank `½(Λ⁻¹ ⊗ Λ⁻¹)` convention; the
+# `(α, β)` block is the standard gamma Fisher information.
+function _mvng_fisher_mean(Λ, W, α, β, d, T)
+    n = d^2 + d + 2
+    F = zeros(T, n, n)
+    r1 = 1:d
+    r2 = (d+1):(d^2+d)
+    i3 = d^2 + d + 1
+    i4 = d^2 + d + 2
+    @inbounds begin
+        F[r1, r1] = (α / β) * Λ
+        F[r2, r2] = (1 / 2) * kron(W, W)
+        F[i3, i3] = SpecialFunctions.trigamma(α)
+        F[i4, i4] = α / β^2
+        F[i3, i4] = -1 / β
+        F[i4, i3] = -1 / β
+    end
+    return F
+end
+
+# Jacobian J = ∂θ/∂η of `NaturalToMean`, with θ = (μ, vec(Λ), α, β) and η = (η₁, vec(η₂), η₃, η₄).
+function _mvng_natural_to_mean_jacobian(μ, W, d, T)
+    n = d^2 + d + 2
+    J = zeros(T, n, n)
+    r1 = 1:d
+    r2 = (d+1):(d^2+d)
+    i3 = d^2 + d + 1
+    i4 = d^2 + d + 2
+    @inbounds begin
+        # μ = Λ⁻¹ η₁,  Λ = -2η₂
+        J[r1, r1] = W
+        J[r1, r2] = 2 * kron(μ', W)
+        # vec(Λ) = -2 vec(η₂)
+        J[r2, r2] = Matrix{T}(-2 * I, d^2, d^2)
+        # α = η₃ - d/2 + 1
+        J[i3, i3] = one(T)
+        # β = -η₄ - ½ η₁ᵀ Λ⁻¹ η₁
+        J[i4, r1] = -μ'
+        J[i4, r2] = -vec(μ * μ')'
+        J[i4, i4] = -one(T)
+    end
+    return J
+end
+
+# Mean parametrization
+
+getlogpartition(::DefaultParametersSpace, ::Type{MvNormalGamma}) = (θ) -> begin
+    (_, Λ, α, β) = unpack_parameters(MvNormalGamma, θ)
+    return loggamma(α) - α * log(β) - (1 / 2) * logdet(Λ)
+end

--- a/src/distributions/mv_normal_gamma.jl
+++ b/src/distributions/mv_normal_gamma.jl
@@ -65,8 +65,8 @@ BayesBase.rate(d::MvNormalGamma)     = getindex(params(d), 4)
 BayesBase.mean(d::MvNormalGamma) = (d.μ, d.α / d.β)
 
 Base.eltype(::MvNormalGamma{T}) where {T} = T
-Base.length(d::MvNormalGamma)  = length(d.μ) + 1
-Base.size(d::MvNormalGamma)    = (length(d),)
+Base.length(d::MvNormalGamma) = length(d.μ) + 1
+Base.size(d::MvNormalGamma) = (length(d),)
 
 function BayesBase.var(d::MvNormalGamma)
     d.α > one(d.α) || error("`var` of `MvNormalGamma` is not defined for `α < 1`")
@@ -84,6 +84,15 @@ function BayesBase.std(d::MvNormalGamma)
     cx, vτ = var(d)
     # Per-component standard deviations of `x` (sqrt of the marginal variances) and of `τ`.
     return (sqrt.(diag(cx)), sqrt(vτ))
+end
+
+# Differential entropy H = −E[log p]. The base measure is constant, so this follows from the
+# joint moments: E[log τ] = ψ(α)−log β, E[τ] = α/β, and E[τ (x−μ)ᵀΛ(x−μ)] = tr(I_d) = d.
+function BayesBase.entropy(dist::MvNormalGamma)
+    (μ, Λ, α, β) = params(dist)
+    d = length(μ)
+    return loggamma(α) - α * log(β) - logdet(Λ) / 2 + (d / 2) * (one(α) + log(twoπ)) + α -
+           (α + d / 2 - one(α)) * (SpecialFunctions.digamma(α) - log(β))
 end
 
 # A sample is packed as a vector `[x₁, …, x_d, τ]`: the first `d` entries are the mean

--- a/test/distributions/mv_normal_gamma_tests.jl
+++ b/test/distributions/mv_normal_gamma_tests.jl
@@ -17,6 +17,23 @@
     @test eltype(dist) === Float64
 end
 
+@testitem "MvNormalGamma: entropy matches Monte Carlo" begin
+    include("distributions_setuptests.jl")
+
+    rng = StableRNG(7)
+    for d in (1, 2, 3)
+        A = randn(rng, d, d)
+        Λ = A * A' + d * I
+        μ = randn(rng, d)
+        α, β = 4.0 + rand(rng), 2.0 + rand(rng)
+        dist = MvNormalGamma(μ, Λ, α, β)
+
+        samples = rand(rng, dist, 500_000)
+        mc = -mean(logpdf(dist, s) for s in samples)
+        @test isapprox(entropy(dist), mc; rtol = 0.03, atol = 0.05)
+    end
+end
+
 @testitem "MvNormalGamma: type promotion" begin
     include("distributions_setuptests.jl")
     using ExponentialFamily: paramfloattype
@@ -147,5 +164,5 @@ end
     @test collect(ηmv) ≈ collect(ηsc)
 
     @test getfisherinformation(NaturalParametersSpace(), MvNormalGamma)(ηmv) ≈
-        getfisherinformation(NaturalParametersSpace(), NormalGamma)(collect(ηsc))
+          getfisherinformation(NaturalParametersSpace(), NormalGamma)(collect(ηsc))
 end

--- a/test/distributions/mv_normal_gamma_tests.jl
+++ b/test/distributions/mv_normal_gamma_tests.jl
@@ -166,3 +166,55 @@ end
     @test getfisherinformation(NaturalParametersSpace(), MvNormalGamma)(ηmv) ≈
           getfisherinformation(NaturalParametersSpace(), NormalGamma)(collect(ηsc))
 end
+
+@testitem "MvNormalGamma: var/cov/std" begin
+    include("distributions_setuptests.jl")
+
+    μ = [0.5, -1.0]
+    Λ = [2.0 0.3; 0.3 1.5]
+    α, β = 3.0, 2.0
+    dist = MvNormalGamma(μ, Λ, α, β)
+
+    # Marginal covariance of `x` is (β / (α - 1)) Λ⁻¹; variance of `τ` is α / β².
+    cx_expected = (β / (α - 1)) * inv(Λ)
+    vτ_expected = α / β^2
+
+    cx, vτ = var(dist)
+    @test cx ≈ cx_expected
+    @test vτ ≈ vτ_expected
+
+    # `cov` aliases `var` for this distribution.
+    @test cov(dist) == var(dist)
+
+    sx, sτ = std(dist)
+    @test sx ≈ sqrt.(diag(cx_expected))
+    @test sτ ≈ sqrt(vτ_expected)
+
+    # `var`/`cov`/`std` are undefined for `α ≤ 1` (the marginal covariance diverges).
+    for bad_α in (1.0, 0.5)
+        bad = MvNormalGamma(μ, Λ, bad_α, β)
+        @test_throws ErrorException var(bad)
+        @test_throws ErrorException cov(bad)
+        @test_throws ErrorException std(bad)
+    end
+end
+
+@testitem "MvNormalGamma: insupport" begin
+    include("distributions_setuptests.jl")
+
+    for d in (1, 2, 3)
+        A = randn(StableRNG(d), d, d)
+        Λ = A * A' + d * I
+        dist = MvNormalGamma(randn(StableRNG(10d), d), Λ, 2.0, 1.0)
+        ef = convert(ExponentialFamilyDistribution, dist)
+
+        # A valid sample is a `(d + 1)`-vector `[x₁, …, x_d, τ]` with `τ > 0`.
+        @test insupport(ef, vcat(zeros(d), 0.5))
+        # Non-positive precision is out of support.
+        @test !insupport(ef, vcat(zeros(d), -0.5))
+        @test !insupport(ef, vcat(zeros(d), 0.0))
+        # Wrong-length vectors are out of support.
+        @test !insupport(ef, zeros(d))
+        @test !insupport(ef, vcat(zeros(d + 1), 0.5))
+    end
+end

--- a/test/distributions/mv_normal_gamma_tests.jl
+++ b/test/distributions/mv_normal_gamma_tests.jl
@@ -1,0 +1,151 @@
+
+@testitem "MvNormalGamma: common" begin
+    include("distributions_setuptests.jl")
+
+    μ = [0.5, -1.0]
+    Λ = [2.0 0.3; 0.3 1.5]
+    α, β = 3.0, 2.0
+    dist = MvNormalGamma(μ, Λ, α, β)
+
+    @test params(dist) == (μ, Λ, α, β)
+    @test location(dist) == μ
+    @test scale(dist) == Λ
+    @test shape(dist) == α
+    @test rate(dist) == β
+    @test mean(dist) == (μ, α / β)
+    @test length(dist) == 3
+    @test eltype(dist) === Float64
+end
+
+@testitem "MvNormalGamma: type promotion" begin
+    include("distributions_setuptests.jl")
+    using ExponentialFamily: paramfloattype
+
+    d1 = MvNormalGamma(rand(Float32, 2), [1.0 0.0; 0.0 1.0], 2.0, 3.0)
+    @test paramfloattype(d1) == Float64
+
+    d2 = MvNormalGamma(rand(Float32, 2), [1.0f0 0.0f0; 0.0f0 1.0f0], 2.0f0, 3.0f0)
+    @test paramfloattype(d2) == Float32
+end
+
+@testitem "MvNormalGamma: logpdf factorizes as MvNormal × Gamma" begin
+    include("distributions_setuptests.jl")
+
+    rng = StableRNG(123)
+    for d in (2, 3)
+        A = randn(rng, d, d)
+        Λ = A * A' + d * I
+        μ = randn(rng, d)
+        α, β = 2.0 + rand(rng), 1.0 + rand(rng)
+        dist = MvNormalGamma(μ, Λ, α, β)
+
+        for _ in 1:5
+            τ = rand(rng, GammaShapeRate(α, β))
+            x = rand(rng, MvNormalMeanPrecision(μ, τ * Λ))
+            sample = vcat(x, τ)
+            expected = logpdf(MvNormalMeanPrecision(μ, τ * Λ), x) + logpdf(GammaShapeRate(α, β), τ)
+            @test logpdf(dist, sample) ≈ expected
+            @test pdf(dist, sample) ≈ exp(expected)
+        end
+    end
+end
+
+@testitem "MvNormalGamma: ExponentialFamilyDistribution interface" begin
+    include("distributions_setuptests.jl")
+
+    rng = StableRNG(42)
+
+    for d in (2, 3)
+        A = randn(rng, d, d)
+        Λ = A * A' + d * I
+        μ = randn(rng, d)
+        α = 2.0 + 10rand(rng)
+        β = 1.0 + 10rand(rng)
+
+        @testset let dist = MvNormalGamma(μ, Λ, α, β)
+            ef = test_exponentialfamily_interface(
+                dist;
+                option_assume_no_allocations = false,
+                # ForwardDiff comparisons are not meaningful here: `η₂` is stored as a free
+                # `d×d` matrix while the family only depends on its symmetric part (the same
+                # reason these are disabled for `MvNormalWishart`).
+                test_gradlogpartition_properties = false,
+                test_fisherinformation_against_hessian = false,
+                test_fisherinformation_against_jacobian = false
+            )
+
+            # gradient equals E[sufficient statistics]; check via sampling without ForwardDiff
+            run_test_gradlogpartition_properties(dist; test_against_forwardiff = false)
+
+            (η1, η2, η3, η4) = unpack_parameters(MvNormalGamma, getnaturalparameters(ef))
+            @test η1 ≈ Λ * μ
+            @test η2 ≈ -Λ / 2
+            @test η3 ≈ α + d / 2 - 1
+            @test η4 ≈ -β - dot(μ, Λ, μ) / 2
+        end
+    end
+end
+
+@testitem "MvNormalGamma: isproper" begin
+    include("distributions_setuptests.jl")
+
+    # Valid natural parameters from a proper distribution
+    d = MvNormalGamma([0.5, -1.0], [2.0 0.3; 0.3 1.5], 3.0, 2.0)
+    η = getnaturalparameters(convert(ExponentialFamilyDistribution, d))
+    @test isproper(NaturalParametersSpace(), MvNormalGamma, η, nothing)
+
+    # Non-positive-definite Λ (η₂ = -Λ/2 must give posdef Λ)
+    bad = copy(collect(η))
+    bad[3] = 10.0  # corrupt an off/diagonal entry of vec(η₂) to break posdefness
+    bad[4] = 10.0
+    @test !isproper(NaturalParametersSpace(), MvNormalGamma, bad, nothing)
+
+    # A conditioner is not supported
+    @test !isproper(NaturalParametersSpace(), MvNormalGamma, η, [1.0])
+    @test !isproper(DefaultParametersSpace(), MvNormalGamma, collect(η), [1.0])
+
+    # NaN / Inf rejected
+    @test !isproper(NaturalParametersSpace(), MvNormalGamma, [NaN, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0], nothing)
+end
+
+@testitem "MvNormalGamma: prod conjugacy" begin
+    include("distributions_setuptests.jl")
+
+    rng = StableRNG(7)
+    for d in (2, 3)
+        A1 = randn(rng, d, d)
+        A2 = randn(rng, d, d)
+        left = MvNormalGamma(randn(rng, d), A1 * A1' + d * I, 2.0 + rand(rng), 1.0 + rand(rng))
+        right = MvNormalGamma(randn(rng, d), A2 * A2' + d * I, 2.0 + rand(rng), 1.0 + rand(rng))
+
+        @test test_generic_simple_exponentialfamily_product(
+            left,
+            right,
+            strategies = (
+                ClosedProd(),
+                GenericProd(),
+                PreserveTypeProd(ExponentialFamilyDistribution),
+                PreserveTypeProd(ExponentialFamilyDistribution{MvNormalGamma})
+            )
+        )
+    end
+end
+
+@testitem "MvNormalGamma: reduces to NormalGamma when d == 1" begin
+    include("distributions_setuptests.jl")
+
+    μ, λ, α, β = 0.7, 1.4, 2.5, 1.1
+    dmv = MvNormalGamma([μ], reshape([λ], 1, 1), α, β)
+    dsc = NormalGamma(μ, λ, α, β)
+
+    for xτ in ([0.3, 0.9], [-1.2, 2.0], [0.0, 0.5])
+        @test logpdf(dmv, xτ) ≈ logpdf(dsc, xτ)
+    end
+
+    ηmv = getnaturalparameters(convert(ExponentialFamilyDistribution, dmv))
+    ηsc = getnaturalparameters(convert(ExponentialFamilyDistribution, dsc))
+    @test collect(ηmv) ≈ collect(ηsc)
+
+    @test getfisherinformation(NaturalParametersSpace(), MvNormalGamma)(ηmv) ≈
+        getfisherinformation(NaturalParametersSpace(), NormalGamma)(collect(ηsc))
+end


### PR DESCRIPTION
For exact Bayesian inference in the autoregressive node, we require its conjugate prior: the multivariate normal - gamma distribution.

```math
\begin{align}
p(\theta, \tau) &= p(\theta | \tau) p(\tau) \\ 
&= N(\theta | \mu, (\tau \Lambda)) G(\tau | \alpha, \beta) \\
&= NG( \theta, \tau | \mu, \Lambda, \alpha, \beta)
\end{align}
```

It is, in essence, a special case of the multivariate normal - wishart distribution. But it's an important case.