### PR TITLE
Fix convert ambiguity for FullNormal under Distributions 0.25.129

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExponentialFamily"
 uuid = "62312e5e-252a-4322-ace9-a5f4bf9b357b"
 authors = ["Ismail Senoz <i.senoz@tue.nl>", "Dmitry Bagaev <d.v.bagaev@tue.nl>"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 BayesBase = "b4ee3484-f114-42fe-b91c-797d54a0c67e"

--- a/src/distributions/normal_family/normal_family.jl
+++ b/src/distributions/normal_family/normal_family.jl
@@ -386,9 +386,18 @@ function Base.convert(::Type{NormalWeightedMeanPrecision}, dist::Normal)
     return NormalWeightedMeanPrecision(precision * mean, precision)
 end
 
-# Special case for `FullNormal` to `NormalWeightedMeanPrecision` from `Distributions`
-
-function Base.convert(::Type{MvNormalWeightedMeanPrecision}, dist::FullNormal)
+# Special case for `FullNormal` to `MvNormalWeightedMeanPrecision` from `Distributions`.
+# We dispatch on the explicit `MvNormal` parametrization (dense `PDMat` covariance) rather than
+# on the `FullNormal` alias directly: since Distributions.jl 0.25.129 `FullNormal` became a
+# parametric `UnionAll` (`FullNormal{T} = MvNormal{T,<:PDMat{T},<:AbstractVector{T}}`), and a bare
+# `dist::FullNormal` method is no longer comparable to the generic `MultivariateNormalDistributionsFamily{T}`
+# conversion above (one is more specific on the covariance/mean, the other on the `T <: Real` bound),
+# producing a method ambiguity. Pinning `T <: Real` here makes this method strictly more specific so it
+# wins unambiguously, and the spelled-out signature works across the whole `Distributions = "0.25"` range.
+function Base.convert(
+    ::Type{MvNormalWeightedMeanPrecision},
+    dist::MvNormal{T, <:Distributions.PDMats.PDMat{T}, <:AbstractVector{T}}
+) where {T <: Real}
     mean, cov = mean_cov(dist)
     precision = cholinv(cov)
     return MvNormalWeightedMeanPrecision(precision * mean, precision)

--- a/test/distributions/normal_family/mv_normal_weighted_mean_precision_tests.jl
+++ b/test/distributions/normal_family/mv_normal_weighted_mean_precision_tests.jl
@@ -157,3 +157,37 @@ end
         convert(MvNormalWeightedMeanPrecision, m, c) == MvNormalWeightedMeanPrecision(m, c)
     end
 end
+
+@testitem "MvNormalWeightedMeanPrecision: convert from Distributions FullNormal (no ambiguity)" begin
+    # Regression test for the method ambiguity exposed by Distributions.jl 0.25.129, which turned
+    # `FullNormal` from a concrete alias into the parametric `FullNormal{T} = MvNormal{T,<:PDMat{T},<:AbstractVector{T}}`.
+    # A bare `dist::FullNormal` convert method then clashed with the generic
+    # `MultivariateNormalDistributionsFamily{T}` conversion. See ReactiveBayes/RxInferBenchmarks.jl CI.
+    include("./normal_family_setuptests.jl")
+    using LinearAlgebra, Distributions, Test
+
+    m = [1.0, -2.0, 0.5]
+    c = [2.0 0.3 0.1; 0.3 3.0 0.2; 0.1 0.2 4.0]
+
+    # A `FullNormal` (dense `PDMat` covariance — Distributions wraps a dense matrix in a `PDMat`)
+    # must convert without an ambiguity error...
+    d = MvNormal(m, c)
+    @test d isa FullNormal
+    w = convert(MvNormalWeightedMeanPrecision, d)
+    @test w isa MvNormalWeightedMeanPrecision
+    @test mean(w) ≈ m
+    @test cov(w) ≈ c
+
+    # ...and Float32 covariances dispatch to the same method.
+    df = MvNormal(Float32.(m), Float32.(c))
+    @test df isa FullNormal
+    @test convert(MvNormalWeightedMeanPrecision, df) isa MvNormalWeightedMeanPrecision
+
+    # Guard: none of the surviving ambiguities touch this convert method.
+    ambs = Test.detect_ambiguities(ExponentialFamily; recursive = true)
+    offending = filter(
+        pair -> any(m -> occursin("MvNormalWeightedMeanPrecision", string(m.sig)), pair),
+        ambs
+    )
+    @test isempty(offending)
+end


### PR DESCRIPTION
## Problem

Scheduled CI in [RxInferBenchmarks.jl](https://github.com/ReactiveBayes/RxInferBenchmarks.jl) started failing (run `28348663904`, 2026-06-29) — the `gaussian_mixture` model errored on **all** Julia versions (1.10/1.11/1.12) with a method ambiguity during message multiplication:

```
MethodError: convert(::Type{MvNormalWeightedMeanPrecision}, ::FullNormal{Float64, PDMat{...}, Vector{Float64}}) is ambiguous.
Candidates:
  convert(::Type{MvNormalWeightedMeanPrecision}, dist::FullNormal{T} where T)                                  @ ExponentialFamily normal_family.jl:391
  convert(::Type{MvNormalWeightedMeanPrecision}, dist::Union{MultivariateNormalDistributionsFamily{T}, ...}) where T<:Real @ ExponentialFamily normal_family.jl:374
```

## Root cause

This is **not** a regression in ExponentialFamily.jl. **Distributions.jl 0.25.129** changed `FullNormal` from a concrete alias

```julia
const FullNormal = MvNormal{Float64, PDMat{Float64,Matrix{Float64}}, Vector{Float64}}   # ≤ 0.25.127, concrete
```

into a parametric `UnionAll`:

```julia
const FullNormal{T} = MvNormal{T,<:PDMat{T},<:AbstractVector{T}}                          # 0.25.129
```

While `FullNormal` was concrete it was strictly more specific than everything in the generic `MultivariateNormalDistributionsFamily{T}` conversion (`MvNormal{T}` ∈ that union), so the special-case method won cleanly. As a parametric type with an unbounded `T`, the special-case method and the generic `where T<:Real` method are no longer comparable — one is more specific on the covariance/mean params, the other on the `T<:Real` bound — so the conversion now errors. RxInferBenchmarks.jl pins nothing and was simply the first ReactiveBayes consumer to resolve the new Distributions.

## Fix

Dispatch the `FullNormal` special case on the explicit `MvNormal` parametrization with a `T <: Real` bound:

```julia
function Base.convert(
    ::Type{MvNormalWeightedMeanPrecision},
    dist::MvNormal{T, <:Distributions.PDMats.PDMat{T}, <:AbstractVector{T}}
) where {T <: Real}
```

This is strictly more specific than the generic union method (so it wins unambiguously), and the spelled-out signature is valid across the whole `Distributions = "0.25"` compat range (it does not depend on `FullNormal` being parametric). Behavior is unchanged — `DiagNormal` still routes through the generic conversion.

## Reproduction

```julia
using ExponentialFamily, Distributions, PDMats, LinearAlgebra
d = MvNormal(zeros(2), PDMat(Matrix{Float64}(I, 2, 2)))   # a FullNormal
convert(MvNormalWeightedMeanPrecision, d)                 # ambiguity error on 0.25.129, fixed here
```

## Verification

- New regression test (convert from a Distributions `FullNormal` succeeds; no surviving ambiguity touches the method) + existing `MvNormalWeightedMeanPrecision` testitems pass against Distributions 0.25.129.
- The original `gaussian_mixture` benchmark suite (RxInfer multivariate NormalMixture + MeanField VI) passes end-to-end (17/17) with this patch dev'd in.

## Follow-up

A registry release (**2.5.1**, bumped here) is required before RxInferBenchmarks.jl CI goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)