### PR TITLE
docs: add beginner guides and fix spelling across docs and docstrings

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,11 @@ makedocs(
     sitename = "ExponentialFamily.jl",
     pages    = [
     "Home"      => "index.md",
+    "Getting Started" => [
+        "What is a Probability Distribution?" => "distributions.md",
+        "What is the Exponential Family?"     => "exponential_family.md",
+        "Comparison with Distributions.jl"    => "comparison.md"
+    ],
     "Interface" => "interface.md",
     "Library"   => "library.md",
     "Examples"  => "examples.md"

--- a/docs/src/comparison.md
+++ b/docs/src/comparison.md
@@ -1,0 +1,94 @@
+# [Comparison with Distributions.jl](@id comparison-distributions)
+
+A common first question is: *how does `ExponentialFamily.jl` relate to
+[`Distributions.jl`](https://github.com/JuliaStats/Distributions.jl)?* The short
+answer is that **`ExponentialFamily.jl` extends `Distributions.jl` — it does not
+replace it.** `Distributions.jl` is a direct dependency, and the two are designed
+to be used together.
+
+## What each package is for
+
+[`Distributions.jl`](https://github.com/JuliaStats/Distributions.jl) is the
+foundational Julia package for probability distributions. It provides a broad
+"zoo" of distributions together with a unified interface for the operations you
+most often need:
+
+- **sampling** random values (`rand`),
+- **evaluating** densities and probabilities (`pdf`, `logpdf`, `cdf`),
+- **summarising** distributions (`mean`, `var`, `params`), and
+- **fitting** distributions to data (`fit`).
+
+`ExponentialFamily.jl` focuses on the subset of distributions that belong to the
+[exponential family](@ref exponential-family-primer) and adds the specialised
+machinery that this shared structure makes possible:
+
+- a **natural-parameter representation** via the generic
+  [`ExponentialFamilyDistribution`](@ref) type,
+- **analytic products** of distributions over the same variable (the core
+  operation behind Bayes' rule and conjugate inference),
+- direct access to **exponential family attributes** — base measure, sufficient
+  statistics, log partition function, and
+  [Fisher information](https://en.wikipedia.org/wiki/Fisher_information), and
+- a number of **extra parameterizations and distributions** that are convenient
+  for inference but are not part of `Distributions.jl` (see the
+  [Library](@ref library-list-distributions-extra) page).
+
+## At a glance
+
+| | `Distributions.jl` | `ExponentialFamily.jl` |
+|---|---|---|
+| Scope | Distributions of all kinds | The exponential family subset |
+| Parameterization | Mean parameters (e.g. mean, variance, probability) | Natural parameters ``\eta``, plus conversions to/from mean parameters |
+| Sampling (`rand`) | ✔ Primary feature | Uses `Distributions.jl` |
+| Density (`pdf`, `logpdf`) | ✔ | ✔ (also in natural form) |
+| Fitting to data (`fit`) | ✔ | Uses `Distributions.jl` |
+| Analytic product of distributions | — | ✔ |
+| Sufficient statistics / log partition / Fisher information | — | ✔ |
+| Relationship | Standalone foundation | Builds on top of `Distributions.jl` |
+
+## Using both together
+
+Because `ExponentialFamily.jl` re-uses the `Distributions.jl` types directly, you
+move between the two worlds with a single `convert` call. Start from an ordinary
+`Distributions.jl` distribution defined by its familiar mean parameters:
+
+```@example comparison
+using ExponentialFamily, Distributions
+
+bernoulli = Bernoulli(0.25) # the usual Distributions.jl distribution
+```
+
+Convert it into its exponential family (natural parameter) representation when you
+need the extra machinery:
+
+```@example comparison
+ef = convert(ExponentialFamilyDistribution, bernoulli)
+```
+
+And convert straight back to the `Distributions.jl` type when you are done:
+
+```@example comparison
+convert(Bernoulli, ef)
+```
+
+The round trip recovers the original distribution. In practice you will keep using
+`Distributions.jl` for sampling and density evaluation, and reach for
+`ExponentialFamily.jl` when you need products, sufficient statistics, or other
+exponential family attributes.
+
+## When should I use which?
+
+- Reach for **`Distributions.jl`** when you want to draw samples, evaluate a
+  density, fit a distribution to data, or work with a distribution that is not in
+  the exponential family.
+- Reach for **`ExponentialFamily.jl`** when you need to multiply distributions
+  analytically (e.g. inside a Bayesian inference routine), or when you need the
+  natural parameters, sufficient statistics, log partition function, or Fisher
+  information of an exponential family member.
+
+## Where to go next
+
+- [The `ExponentialFamilyDistribution` Interface](@ref interface) — the full API.
+- [Examples](@ref examples) — products and attribute computations in action.
+- [Library](@ref library-list-distributions-extra) — the additional
+  distributions provided by this package.

--- a/docs/src/distributions.md
+++ b/docs/src/distributions.md
@@ -1,0 +1,99 @@
+# [What is a Probability Distribution?](@id distributions-primer)
+
+!!! note
+    This page is written for newcomers to probability theory. If you are already
+    comfortable with random variables, densities, and parameters, feel free to
+    jump straight to [What is the Exponential Family?](@ref exponential-family-primer)
+    or to the [interface description](@ref interface).
+
+## Random variables and uncertainty
+
+Many quantities in the real world are *uncertain*: the outcome of a coin flip,
+the height of the next person to walk through a door, the number of emails you
+will receive tomorrow. A **random variable** is simply a name for such an
+uncertain quantity. We usually write it with a capital letter, e.g. ``X``.
+
+A **probability distribution** is the mathematical object that describes *how
+likely* each possible value of a random variable is. It answers questions like
+"how probable is it that ``X`` equals 3?" or "how probable is it that ``X`` lands
+between 1.0 and 2.0?".
+
+Distributions come in two broad flavours:
+
+- **Discrete** distributions describe variables that take values from a countable
+  set, such as `0`/`1` (a coin flip) or the non-negative integers (a count).
+- **Continuous** distributions describe variables that take values on a continuum,
+  such as any real number (a temperature measurement).
+
+## Probability mass and probability density
+
+For a **discrete** random variable, the distribution is summarised by a
+*probability mass function* (PMF), written ``p(x)``. It gives the probability that
+the variable equals a specific value, and all the probabilities sum to one.
+
+The simplest example is the [`Bernoulli`](https://juliastats.org/Distributions.jl/stable/univariate/#Distributions.Bernoulli)
+distribution, which models a single yes/no (or `1`/`0`) event such as a biased
+coin flip. It has a single parameter ``p``, the probability of observing a `1`:
+
+```@example dist-primer
+using ExponentialFamily, Distributions
+
+coin = Bernoulli(0.25) # a coin that lands "1" 25% of the time
+
+(pdf(coin, 1), pdf(coin, 0)) # probabilities of the two possible outcomes
+```
+
+The two numbers add up to one, because `1` and `0` are the only possible
+outcomes.
+
+For a **continuous** random variable we cannot talk about the probability of an
+*exact* value (that probability is zero), so instead we use a *probability density
+function* (PDF), also written ``p(x)``. The density itself is not a probability;
+rather, the *area* under the density over an interval gives the probability of
+landing in that interval.
+
+The most famous continuous distribution is the
+[`Normal`](https://juliastats.org/Distributions.jl/stable/univariate/#Distributions.Normal)
+(or Gaussian) distribution, the familiar bell curve:
+
+```@example dist-primer
+bell = Normal(0.0, 1.0) # mean 0, standard deviation 1
+
+pdf(bell, 0.0) # the density is highest at the mean
+```
+
+## Parameters
+
+Notice that both `Bernoulli(0.25)` and `Normal(0.0, 1.0)` were created by giving
+a few numbers. These numbers are the **parameters** of the distribution: they
+pin down one specific distribution from a whole family of related shapes. The
+`Bernoulli` family is indexed by a single probability ``p``; the `Normal` family
+is indexed by a mean ``\mu`` and a variance (or standard deviation) ``\sigma``.
+
+These "human-friendly" parameters — a probability, a mean, a variance — are what
+we call the **mean parameters** of a distribution. You can always read them back
+from a distribution with `params`, `mean`, and `var`:
+
+```@example dist-primer
+(params(bell), mean(bell), var(bell))
+```
+
+## Why a package specifically for the *exponential family*?
+
+The [`Distributions.jl`](https://github.com/JuliaStats/Distributions.jl) package
+already provides a large collection of distributions together with sampling,
+fitting, and density evaluation. So why does `ExponentialFamily.jl` exist?
+
+It turns out that most of the distributions you meet in practice — `Bernoulli`,
+`Normal`, `Gamma`, `Poisson`, and many more — share a common mathematical
+structure. They all belong to a single, unifying class called the
+**exponential family**. Writing a distribution in this common form unlocks
+operations that are central to Bayesian inference, most notably *analytic
+products* of distributions and direct access to quantities such as sufficient
+statistics, the log partition function, and Fisher information.
+
+`ExponentialFamily.jl` builds directly on top of `Distributions.jl` and adds
+exactly this machinery. The next page explains what the exponential family is and
+why this shared structure is so useful.
+
+**Next:** [What is the Exponential Family?](@ref exponential-family-primer)

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -92,7 +92,7 @@ basemeasure_of_laplace = getbasemeasure(Laplace, 2.0)
 basemeasure_of_laplace(1.0)
 ```
 
-The [`getlogpartition`](@ref) and [`getfisherinformation`](@ref) functions optionally accept a `space` parameter as the first argument. This `space` parameter specifies the parameterization `space`, such as [`DefaultParametersSpace`](@ref) or [`NaturalParametersSpace`]. The result obtained from these functions (in general) depends on the chosen parameter space:
+The [`getlogpartition`](@ref) and [`getfisherinformation`](@ref) functions optionally accept a `space` parameter as the first argument. This `space` parameter specifies the parameterization `space`, such as [`DefaultParametersSpace`](@ref) or [`NaturalParametersSpace`](@ref). The result obtained from these functions (in general) depends on the chosen parameter space:
 
 ```@example attributes-example
 logpartition_of_gamma_in_mean_space = getlogpartition(DefaultParametersSpace(), Gamma)
@@ -103,7 +103,7 @@ logpartition_of_gamma_in_mean_space(gamma_parameters_in_mean_space)
 ```
 
 ```@example attributes-example
-logparition_of_gamma_in_natural_space = getlogpartition(NaturalParametersSpace(), Gamma)
+logpartition_of_gamma_in_natural_space = getlogpartition(NaturalParametersSpace(), Gamma)
 
 gamma_parameters_in_natural_space = map(
     DefaultParametersSpace() => NaturalParametersSpace(), 
@@ -111,7 +111,7 @@ gamma_parameters_in_natural_space = map(
     gamma_parameters_in_mean_space
 )
 
-logparition_of_gamma_in_natural_space(gamma_parameters_in_natural_space)
+logpartition_of_gamma_in_natural_space(gamma_parameters_in_natural_space)
 ```
 
 The same principle applies to the Fisher information matrix:

--- a/docs/src/exponential_family.md
+++ b/docs/src/exponential_family.md
@@ -1,0 +1,140 @@
+# [What is the Exponential Family?](@id exponential-family-primer)
+
+!!! note
+    This page introduces the exponential family from scratch. For the precise
+    API and implementation details, continue to the [interface description](@ref interface).
+    If the term "probability distribution" is unfamiliar, start with
+    [What is a Probability Distribution?](@ref distributions-primer).
+
+## A common form for many distributions
+
+At first glance the [`Bernoulli`](https://juliastats.org/Distributions.jl/stable/univariate/#Distributions.Bernoulli),
+[`Normal`](https://juliastats.org/Distributions.jl/stable/univariate/#Distributions.Normal),
+[`Gamma`](https://juliastats.org/Distributions.jl/stable/univariate/#Distributions.Gamma),
+and [`Poisson`](https://juliastats.org/Distributions.jl/stable/univariate/#Distributions.Poisson)
+distributions look completely different. Remarkably, all of them — and most other
+distributions you will encounter — can be written in one and the same shape:
+
+```math
+p_X(x \mid \eta) = h(x) \cdot \exp\!\left[\, \eta \cdot T(x) - A(\eta) \,\right]
+```
+
+A distribution that can be written this way is said to belong to the
+**exponential family**. Each symbol plays a specific role:
+
+- **``\eta`` — the natural parameters.** These are the parameters of the
+  distribution, but expressed in a special "canonical" coordinate system rather
+  than the human-friendly mean parameters (a probability, a mean, a variance).
+- **``T(x)`` — the sufficient statistics.** A function (or several functions) of
+  the data. The name reflects a deep fact: ``T(x)`` captures *everything* the data
+  can tell you about ``\eta``. Once you know ``T(x)``, the raw data carries no extra
+  information about the parameters.
+- **``A(\eta)`` — the log partition function** (also called the cumulant
+  function). It is the bookkeeping term that guarantees the probabilities
+  integrate (or sum) to one. Its derivatives also produce useful quantities such
+  as the mean of the sufficient statistics and the Fisher information.
+- **``h(x)`` — the base measure.** A non-negative function of the data that does
+  not depend on the parameters. For many distributions it is simply `1`.
+
+You do not need to memorise this formula to use the package. The important
+takeaway is that *one* template describes a huge collection of distributions, so a
+single, generic interface can serve all of them.
+
+## Seeing the pieces in code
+
+`ExponentialFamily.jl` lets you take any supported `Distributions.jl`
+distribution and view it in this canonical form. The conversion is done with
+`convert`:
+
+```@example ef-primer
+using ExponentialFamily, Distributions
+
+bernoulli = Bernoulli(0.25)
+
+ef = convert(ExponentialFamilyDistribution, bernoulli)
+```
+
+Now we can inspect each ingredient of the exponential family form. The natural
+parameters ``\eta`` are stored in a packed (vectorised) form:
+
+```@example ef-primer
+getnaturalparameters(ef)
+```
+
+For the `Bernoulli` distribution the single natural parameter is the *log-odds*
+``\log\frac{p}{1-p}``, which is a different coordinate system than the probability
+``p = 0.25`` we started with. The sufficient statistic ``T(x)`` is just ``x``
+itself:
+
+```@example ef-primer
+getsufficientstatistics(ef)
+```
+
+And the log partition function ``A(\eta)`` is available as a callable function of
+the natural parameters:
+
+```@example ef-primer
+logpartition(ef)
+```
+
+The same pattern works for any supported distribution. The full set of accessor
+functions — `getbasemeasure`, `getsufficientstatistics`, `getlogpartition`,
+`getgradlogpartition`, `getfisherinformation`, `getsupport`, and more — is
+documented on the [interface page](@ref interface).
+
+## Why the exponential family matters
+
+Casting distributions into this shared form is not just mathematical elegance —
+it enables operations that are at the heart of probabilistic inference.
+
+### Products of distributions are easy
+
+In Bayesian inference, combining a prior with a likelihood (Bayes' rule) requires
+*multiplying* two distributions over the same variable. A wonderful property of
+the exponential family is that the product of two members of the same family is
+*again* a member of that family, and the natural parameters simply **add**. This
+makes the operation exact and cheap:
+
+```@example ef-primer
+using BayesBase
+
+prior      = Bernoulli(0.5)
+likelihood = Bernoulli(0.6)
+
+posterior = prod(PreserveTypeProd(Distribution), prior, likelihood)
+```
+
+For distributions whose product cannot be written back in the original form, the
+computation can still be carried out exactly in the exponential family
+representation. See the [Examples](@ref examples-product) page for a deeper look.
+
+### Sufficient statistics and analytic attributes
+
+Because the structure is shared, quantities that are otherwise tedious to derive
+by hand — the base measure, sufficient statistics, the log partition function,
+and the [Fisher information](https://en.wikipedia.org/wiki/Fisher_information) —
+are all implemented analytically and exposed through one uniform interface. These
+are the building blocks of conjugate inference, variational methods, and
+natural-gradient optimisation.
+
+### One interface for many distributions
+
+Finally, the exponential family gives the package a single, generic
+`ExponentialFamilyDistribution` type that can represent any of its members. Code
+written against this interface automatically works for every supported
+distribution.
+
+## Where to go next
+
+- [Comparison with Distributions.jl](@ref comparison-distributions) — how this
+  package relates to and extends `Distributions.jl`.
+- [The `ExponentialFamilyDistribution` Interface](@ref interface) — the complete
+  API reference.
+- [Examples](@ref examples) — worked examples of products and attribute
+  computations.
+
+If you would like a more formal treatment, the
+[Wikipedia article on the exponential family](https://en.wikipedia.org/wiki/Exponential_family)
+is an excellent reference, including a
+[table](https://en.wikipedia.org/wiki/Exponential_family#Table_of_distributions)
+of the canonical form for many common distributions.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,6 +12,15 @@ The package is built around several core principles:
 
 ## Table of Contents
 
+New to probability distributions or the exponential family? Start with the
+beginner-friendly **Getting Started** pages:
+
+* [What is a Probability Distribution?](@ref distributions-primer)
+* [What is the Exponential Family?](@ref exponential-family-primer)
+* [Comparison with Distributions.jl](@ref comparison-distributions)
+
+Then dive into the rest of the documentation:
+
 * [Interface](@ref interface)
 * [Examples](@ref examples)
 * [Library](@ref library)

--- a/docs/src/interface.md
+++ b/docs/src/interface.md
@@ -94,7 +94,7 @@ And to convert back:
 tuple_of_θ = NaturalToMean(Bernoulli)(tuple_of_η)
 ```
 
-Alternatuvely, the following API is supported 
+Alternatively, the following API is supported
 
 ```@example dist-interfacing
 map(DefaultParametersSpace() => NaturalParametersSpace(), Bernoulli, tuple_of_θ)
@@ -156,7 +156,7 @@ ExponentialFamily.pack_parameters
 ExponentialFamily.unpack_parameters
 ```
 
-These functions are not exported by default, but it's important to note that the `ExponentialFamilyDistributions` type doesn't actually store the parameter tuple internally. Instead, the `getnaturalparameters` function returns the corresponding vectorized (packed) form of the natural parameters. In general, only the `ExponentialFamily.unpack_parameters` function must be implemented, as others could be implemented in a generic way.
+These functions are not exported by default, but it's important to note that the `ExponentialFamilyDistribution` type doesn't actually store the parameter tuple internally. Instead, the `getnaturalparameters` function returns the corresponding vectorized (packed) form of the natural parameters. In general, only the `ExponentialFamily.unpack_parameters` function must be implemented, as others could be implemented in a generic way.
 
 ### Attributes of the exponential family distribution based on `Distribution`
 
@@ -164,9 +164,9 @@ The `ExponentialFamilyDistribution{T} where { T <: Distribution }` type encompas
 
 
 ```@example dist-interfacing
-basemeasure_of_bernoilli = getbasemeasure(Bernoulli)
+basemeasure_of_bernoulli = getbasemeasure(Bernoulli)
 
-basemeasure_of_bernoilli(0)
+basemeasure_of_bernoulli(0)
 ```
 
 ```@docs

--- a/src/distributions/categorical.jl
+++ b/src/distributions/categorical.jl
@@ -84,7 +84,7 @@ getlogpartition(::NaturalParametersSpace, ::Type{Categorical}, conditioner) =
         if (conditioner !== length(η))
             throw(
                 DimensionMismatch(
-                    lazy"Cannot evaluate the logparition of the `Categorical` with `conditioner = $(conditioner)` and vector of natural parameters `η = $(η)`"
+                    lazy"Cannot evaluate the logpartition of the `Categorical` with `conditioner = $(conditioner)` and vector of natural parameters `η = $(η)`"
                 )
             )
         end
@@ -96,7 +96,7 @@ getgradlogpartition(::NaturalParametersSpace, ::Type{Categorical}, conditioner) 
         if (conditioner !== length(η))
             throw(
                 DimensionMismatch(
-                    lazy"Cannot evaluate the logparition of the `Categorical` with `conditioner = $(conditioner)` and vector of natural parameters `η = $(η)`"
+                    lazy"Cannot evaluate the logpartition of the `Categorical` with `conditioner = $(conditioner)` and vector of natural parameters `η = $(η)`"
                 )
             )
         end
@@ -136,7 +136,7 @@ getlogpartition(::DefaultParametersSpace, ::Type{Categorical}, conditioner) =
         if (conditioner !== length(θ))
             throw(
                 DimensionMismatch(
-                    lazy"Cannot evaluate the logparition of the `Categorical` with `conditioner = $(conditioner)` and vector of mean parameters `θ = $(θ)`"
+                    lazy"Cannot evaluate the logpartition of the `Categorical` with `conditioner = $(conditioner)` and vector of mean parameters `θ = $(θ)`"
                 )
             )
         end

--- a/src/exponential_family.jl
+++ b/src/exponential_family.jl
@@ -204,11 +204,11 @@ Here:
 For a given member of exponential family: 
 
 - `getattributes` returns either `nothing` or `ExponentialFamilyDistributionAttributes`.
-- `getbasemeasure` returns a positive a valued function. 
+- `getbasemeasure` returns a positive-valued function.
 - `getsufficientstatistics` returns an iterable of functions such as [x, x^2] or [x, logx].
-- `getnaturalparameters` returns an iterable holding the values of the natural parameters. 
-- `getlogpartition` return a function that depends on the naturalparameters and it ensures that the distribution is normalized to 1. 
-- `getsupport` returns the set that the distribution is defined over. Could be real numbers, positive integers, 3d cube etc. Use ither the `∈` operator or the `insupport()` function to check if a value belongs to the support.
+- `getnaturalparameters` returns an iterable holding the values of the natural parameters.
+- `getlogpartition` returns a function that depends on the natural parameters and ensures that the distribution is normalized to 1.
+- `getsupport` returns the set that the distribution is defined over. For example, the real numbers, the positive integers, a 3D cube, etc. Use either the `∈` operator or the `insupport()` function to check if a value belongs to the support.
 
 !!! note
     The `attributes` can be `nothing`. In which case the package will try to derive the corresponding attributes from the type `T`.
@@ -296,7 +296,7 @@ getconditioner(ef::ExponentialFamilyDistribution) = ef.conditioner
 """
     getattributes(::ExponentialFamilyDistribution)
 
-Returns iether the attributes of the exponential family member or `nothing`.
+Returns either the attributes of the exponential family member or `nothing`.
 
 See also: [`ExponentialFamilyDistributionAttributes`](@ref)
 """
@@ -476,7 +476,7 @@ end
 """
     isproper([ space = NaturalParametersSpace() ], ::Type{T}, parameters, conditioner = nothing) where { T <: Distribution }
 
-A specific verion of `isproper` defined particularly for distribution types from `Distributions.jl` package.
+A specific version of `isproper` defined particularly for distribution types from `Distributions.jl` package.
 Does not require an instance of the `ExponentialFamilyDistribution` and can be called directly with a specific distribution type instead.
 Optionally, accepts the `space` parameter, which defines the parameters space.
 For conditional exponential family distributions requires an extra `conditioner` argument.
@@ -493,7 +493,7 @@ isproper(ef::ExponentialFamilyDistribution{T}) where {T <: Distribution} =
 """
     getbasemeasure(::Type{<:Distribution}, [ conditioner ])
 
-A specific verion of `getbasemeasure` defined particularly for distribution types from `Distributions.jl` package.
+A specific version of `getbasemeasure` defined particularly for distribution types from `Distributions.jl` package.
 Does not require an instance of the `ExponentialFamilyDistribution` and can be called directly with a specific distribution type instead.
 For conditional exponential family distributions requires an extra `conditioner` argument.
 """
@@ -502,7 +502,7 @@ getbasemeasure(::Type{T}, ::Nothing) where {T <: Distribution} = getbasemeasure(
 """
     getlogbasemeasure(::Type{<:Distribution}, [ conditioner ])
 
-A generic verion of `getlogbasemeasure` defined particularly for distribution types from `Distributions.jl` package.
+A generic version of `getlogbasemeasure` defined particularly for distribution types from `Distributions.jl` package.
 Just computes log of basemeasure.
 """
 getlogbasemeasure(::Type{T}) where {T <: Distribution} = (x) -> log(getbasemeasure(T)(x))
@@ -510,7 +510,7 @@ getlogbasemeasure(::Type{T}) where {T <: Distribution} = (x) -> log(getbasemeasu
 """
     getlogbasemeasure(::Type{<:Distribution}, [ conditioner ])
 
-A generic verion of `getbasemeasure` defined particularly for distribution types from `Distributions.jl` package.
+A generic version of `getbasemeasure` defined particularly for distribution types from `Distributions.jl` package.
 For conditional exponential family distributions requires an extra `conditioner` argument. Just computes log of basemeasure.
 """
 getlogbasemeasure(::Type{T}, ::Nothing) where {T <: Distribution} = getlogbasemeasure(T)
@@ -518,7 +518,7 @@ getlogbasemeasure(::Type{T}, ::Nothing) where {T <: Distribution} = getlogbaseme
 """
     getsufficientstatistics(::Type{<:Distribution}, [ conditioner ])
 
-A specific verion of `getsufficientstatistics` defined particularly for distribution types from `Distributions.jl` package.
+A specific version of `getsufficientstatistics` defined particularly for distribution types from `Distributions.jl` package.
 Does not require an instance of the `ExponentialFamilyDistribution` and can be called directly with a specific distribution type instead.
 For conditional exponential family distributions requires an extra `conditioner` argument.
 """
@@ -527,7 +527,7 @@ getsufficientstatistics(::Type{T}, ::Nothing) where {T <: Distribution} = getsuf
 """
     getlogpartition([ space = NaturalParametersSpace() ], ::Type{T}, [ conditioner ]) where { T <: Distribution }
 
-A specific verion of `getlogpartition` defined particularly for distribution types from `Distributions.jl` package.
+A specific version of `getlogpartition` defined particularly for distribution types from `Distributions.jl` package.
 Does not require an instance of the `ExponentialFamilyDistribution` and can be called directly with a specific distribution type instead.
 Optionally, accepts the `space` parameter, which defines the parameters space.
 For conditional exponential family distributions requires an extra `conditioner` argument.
@@ -545,7 +545,7 @@ getlogpartition(
 """
     getgradlogpartition([ space = NaturalParametersSpace() ], ::Type{T}, [ conditioner ]) where { T <: Distribution }
 
-A specific verion of `getgradlogpartition` defined particularly for distribution types from `Distributions.jl` package.
+A specific version of `getgradlogpartition` defined particularly for distribution types from `Distributions.jl` package.
 Does not require an instance of the `ExponentialFamilyDistribution` and can be called directly with a specific distribution type instead.
 Optionally, accepts the `space` parameter, which defines the parameters space.
 For conditional exponential family distributions requires an extra `conditioner` argument.
@@ -561,7 +561,7 @@ getgradlogpartition(
 """
     getfisherinformation([ space = NaturalParametersSpace() ], ::Type{T}) where { T <: Distribution }
 
-A specific verion of `getfisherinformation` defined particularly for distribution types from `Distributions.jl` package.
+A specific version of `getfisherinformation` defined particularly for distribution types from `Distributions.jl` package.
 Does not require an instance of the `ExponentialFamilyDistribution` and can be called directly with a specific distribution type instead.
 Optionally, accepts the `space` parameter, which defines the parameters space.
 For conditional exponential family distributions requires an extra `conditioner` argument.
@@ -615,12 +615,12 @@ function BayesBase.logpdf(ef::ExponentialFamilyDistribution, x)
 end
 
 """
-A trait object, signifying that the _logpdf method should treat it second argument as one point from the distrubution domain.
+A trait object, signifying that the `_logpdf` method should treat its second argument as one point from the distribution domain.
 """
 struct PointBasedLogpdfCall end
 
 """
-A trait object, signifying that the _logpdf method should treat it second argument as a container of points from the distrubution domain.
+A trait object, signifying that the `_logpdf` method should treat its second argument as a container of points from the distribution domain.
 """
 struct MapBasedLogpdfCall end
 


### PR DESCRIPTION
## Summary

A comprehensive read-through of the documentation and docstrings, fixing spelling/grammar and adding beginner-oriented onboarding content.

### New beginner pages
Added a **Getting Started** navigation group (before *Interface*) with three pages aimed at readers unfamiliar with the topic. All use runnable `@example` blocks, verified at doc build time:

- **What is a Probability Distribution?** — random variables, discrete vs. continuous, PMF/PDF, parameters.
- **What is the Exponential Family?** — the canonical form `h(x) exp[η·T(x) − A(η)]` explained piece by piece, why it matters (analytic products, sufficient statistics, one interface).
- **Comparison with Distributions.jl** — what each package is for, a contrast table, and how to move between the two with `convert`. Makes clear this package *extends* (does not replace) Distributions.jl.

### Spelling / grammar fixes
- `src/exponential_family.jl`: `verion`→`version` (×8), `iether`/`ither`→`either`, `distrubution`→`distribution` (×2), plus grammar fixes in the `ExponentialFamilyDistribution` docstring (`return`→`returns`, `positive a valued`→`positive-valued`, `treat it second argument`→`treat its second argument`, awkward support sentence).
- `src/distributions/categorical.jl`: `logparition`→`logpartition` (×3, in error messages).
- `docs/src/interface.md`: `Alternatuvely`→`Alternatively`, `ExponentialFamilyDistributions`→`ExponentialFamilyDistribution`, `bernoilli`→`bernoulli`.
- `docs/src/examples.md`: `logparition_…` variable rename and a broken `[\`NaturalParametersSpace\`]` cross-reference fixed to `(@ref)`.

### Navigation
- `docs/make.jl`: new *Getting Started* group.
- `docs/src/index.md`: TOC now points newcomers to the three primers first.

## Verification
- Typo sweep across `src/` and `docs/src/` is clean.
- `julia --project=docs docs/make.jl` completes with no doctest failures, no broken `@ref`s, and no missing-docstring warnings. All three new pages render under `docs/build/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)