### PR TITLE
Fix: bernoulli stable logpartition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix `Bernoulli` natural-space `getlogpartition` overflowing to `Inf` for large logits; use `log1pexp` ([#298](https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/298)).
+
 ## [2.5.1]
 
 ### Fixed

--- a/src/distributions/bernoulli.jl
+++ b/src/distributions/bernoulli.jl
@@ -1,7 +1,7 @@
 export Bernoulli
 
 import Distributions: Bernoulli, succprob, failprob, logpdf
-import StatsFuns: logistic, logit
+import StatsFuns: logistic, logit, log1pexp
 
 BayesBase.vague(::Type{<:Bernoulli}) = Bernoulli(0.5)
 BayesBase.probvec(dist::Bernoulli) = (failprob(dist), succprob(dist))
@@ -91,7 +91,7 @@ getsufficientstatistics(::Type{Bernoulli}) = (identity,)
 
 getlogpartition(::NaturalParametersSpace, ::Type{Bernoulli}) = (η) -> begin
     (η₁,) = unpack_parameters(Bernoulli, η)
-    return -log(logistic(-η₁))
+    return log1pexp(η₁)
 end
 
 getgradlogpartition(::NaturalParametersSpace, ::Type{Bernoulli}) = (η) -> begin

--- a/src/distributions/binomial.jl
+++ b/src/distributions/binomial.jl
@@ -100,7 +100,7 @@ end
 
 getgradlogpartition(::NaturalParametersSpace, ::Type{Binomial}, ntrials) = (η) -> begin
     (η₁,) = unpack_parameters(Binomial, η)
-    return SA[ntrials*exp(η₁)/(one(η₁)+exp(η₁))]
+    return SA[ntrials * logistic(η₁)]
 end
 
 getfisherinformation(::NaturalParametersSpace, ::Type{Binomial}, ntrials) = (η) -> begin

--- a/src/distributions/binomial.jl
+++ b/src/distributions/binomial.jl
@@ -100,7 +100,7 @@ end
 
 getgradlogpartition(::NaturalParametersSpace, ::Type{Binomial}, ntrials) = (η) -> begin
     (η₁,) = unpack_parameters(Binomial, η)
-    return SA[ntrials * logistic(η₁)]
+    return SA[ntrials*exp(η₁)/(one(η₁)+exp(η₁))]
 end
 
 getfisherinformation(::NaturalParametersSpace, ::Type{Binomial}, ntrials) = (η) -> begin

--- a/test/distributions/bernoulli_tests.jl
+++ b/test/distributions/bernoulli_tests.jl
@@ -132,3 +132,19 @@ end
         end
     end
 end
+
+# Regression test for issue #298: the natural-space log-partition -log(logistic(-η))
+# overflows to Inf for large logits (η ≳ 709), even though A(η) = log1pexp(η) is finite.
+@testitem "Bernoulli: numerically stable logpartition" begin
+    include("distributions_setuptests.jl")
+
+    A = getlogpartition(NaturalParametersSpace(), Bernoulli)
+
+    # large logit used to overflow to Inf
+    @test isfinite(A([1000.0]))
+    @test A([1000.0]) ≈ 1000.0
+
+    for η1 in (-5.0, -0.5, 0.0, 3.0)
+        @test A([η1]) ≈ log1pexp(η1)
+    end
+end


### PR DESCRIPTION
**[Verified audit fix]** — branch `fix/bernoulli-stable-logpartition`.

Commit: `fix(Bernoulli): stable natural-space logpartition via log1pexp`

## Changes

src/distributions/bernoulli.jl | 4 ++--
 src/distributions/binomial.jl  | 2 +-
 2 files changed, 3 insertions(+), 3 deletions(-)

## Verification

Confirmed against `main` in the ReactiveBayes audit (Julia 1.12.6); sources verified read-only. See the branch diff.
