### PR TITLE
Fix: binomial stable grad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix `Binomial` natural-space `getgradlogpartition` returning `NaN` for large logits; use `logistic` ([#297](https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/297)).
+
 ## [2.5.1]
 
 ### Fixed

--- a/src/distributions/binomial.jl
+++ b/src/distributions/binomial.jl
@@ -100,7 +100,7 @@ end
 
 getgradlogpartition(::NaturalParametersSpace, ::Type{Binomial}, ntrials) = (η) -> begin
     (η₁,) = unpack_parameters(Binomial, η)
-    return SA[ntrials*exp(η₁)/(one(η₁)+exp(η₁))]
+    return SA[ntrials * logistic(η₁)]
 end
 
 getfisherinformation(::NaturalParametersSpace, ::Type{Binomial}, ntrials) = (η) -> begin

--- a/test/distributions/binomial_tests.jl
+++ b/test/distributions/binomial_tests.jl
@@ -85,3 +85,24 @@ end
         end
     end
 end
+
+# Regression test for issue #297: the natural-space gradient of the log-partition used
+# n·exp(η)/(1+exp(η)), which becomes NaN for large logits (η ≳ 709). The fix uses
+# n·logistic(η), consistent with the stable log1pexp log-partition.
+@testitem "Binomial: numerically stable gradlogpartition" begin
+    include("distributions_setuptests.jl")
+
+    n = 100
+    A = getlogpartition(NaturalParametersSpace(), Binomial, n)
+    grad = getgradlogpartition(NaturalParametersSpace(), Binomial, n)
+
+    # large logit used to produce NaN
+    @test isfinite(only(grad([1000.0])))
+    @test only(grad([1000.0])) ≈ n
+    @test grad([1000.0]) ≈ ForwardDiff.gradient(A, [1000.0])
+
+    for η1 in (-3.0, 0.0, 2.5)
+        @test grad([η1]) ≈ [n * logistic(η1)]
+        @test grad([η1]) ≈ ForwardDiff.gradient(A, [η1])
+    end
+end


### PR DESCRIPTION
**[Verified audit fix]** — branch `fix/binomial-stable-grad`.

Commit: `fix(Binomial): stable natural-space gradlogpartition via logistic`

## Changes

src/distributions/binomial.jl | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

## Verification

Confirmed against `main` in the ReactiveBayes audit (Julia 1.12.6); sources verified read-only. See the branch diff.
