### PR TITLE
Fix: categorical stable softmax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix `Categorical` natural-space gradient and Fisher information becoming `NaN` for large natural parameters; compute both via `softmax` ([#294](https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/294)).
+
 ## [2.5.1]
 
 ### Fixed

--- a/src/distributions/categorical.jl
+++ b/src/distributions/categorical.jl
@@ -100,8 +100,7 @@ getgradlogpartition(::NaturalParametersSpace, ::Type{Categorical}, conditioner) 
                 )
             )
         end
-        sumη = mapreduce(exp, +, η)
-        return map(d -> exp(d) / sumη, η)
+        return softmax(η)
     end
 
 getfisherinformation(::NaturalParametersSpace, ::Type{Categorical}, conditioner) =
@@ -113,19 +112,8 @@ getfisherinformation(::NaturalParametersSpace, ::Type{Categorical}, conditioner)
                 )
             )
         end
-        I = Matrix{eltype(η)}(undef, length(η), length(η))
-        ∑expη = sum(exp, η)
-        ∑expη² = abs2(∑expη)
-        @inbounds for i in 1:length(η)
-            expηᵢ = exp(η[i])
-            I[i, i] = expηᵢ * (∑expη - expηᵢ) / ∑expη²
-            for j in 1:(i-1)
-                offv = -expηᵢ * exp(η[j]) / ∑expη²
-                I[i, j] = offv
-                I[j, i] = offv
-            end
-        end
-        return I
+        p = softmax(η)
+        return Diagonal(p) - p * p'
     end
 
 # Mean parametrization

--- a/test/distributions/categorical_tests.jl
+++ b/test/distributions/categorical_tests.jl
@@ -125,3 +125,27 @@ end
         end
     end
 end
+
+# Regression test for issue #294: the natural-space gradient and Fisher used raw exp(η),
+# which overflows to Inf/NaN for large natural parameters, even though the log-partition
+# is computed with the stable logsumexp. The fix uses softmax(η).
+@testitem "Categorical: numerically stable gradient & Fisher" begin
+    include("distributions_setuptests.jl")
+
+    A = getlogpartition(NaturalParametersSpace(), Categorical, 3)
+    grad = getgradlogpartition(NaturalParametersSpace(), Categorical, 3)
+    fisher = getfisherinformation(NaturalParametersSpace(), Categorical, 3)
+
+    # extreme natural parameters used to overflow exp() -> NaN
+    η = [800.0, 810.0, 0.0]
+    @test all(isfinite, grad(η))
+    @test all(isfinite, fisher(η))
+    @test grad(η) ≈ ForwardDiff.gradient(A, η)
+
+    # matches the intended definition (softmax) at modest parameters
+    ηm = [0.5, -1.0, 2.0]
+    p = exp.(ηm) ./ sum(exp.(ηm))
+    @test grad(ηm) ≈ p
+    @test fisher(ηm) ≈ Diagonal(p) - p * p'
+    @test fisher(ηm) ≈ ForwardDiff.hessian(A, ηm)
+end


### PR DESCRIPTION
**[Verified audit fix]** — branch `fix/categorical-stable-softmax`.

Commit: `fix(Categorical): numerically stable gradient & Fisher via softmax`

## Changes

src/distributions/categorical.jl | 18 +++---------------
 1 file changed, 3 insertions(+), 15 deletions(-)

## Verification

Confirmed against `main` in the ReactiveBayes audit (Julia 1.12.6); sources verified read-only. See the branch diff.
