### PR TITLE
Fix: geometric default grad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix `Geometric` default-space `getgradlogpartition` returning the wrong derivative ([#293](https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/293)).
+
 ## [2.5.1]
 
 ### Fixed

--- a/src/distributions/geometric.jl
+++ b/src/distributions/geometric.jl
@@ -68,5 +68,5 @@ end
 
 getgradlogpartition(::DefaultParametersSpace, ::Type{Geometric}) = (θ) -> begin
     (p,) = unpack_parameters(Geometric, θ)
-    return SA[one(p) / (p^2 - p);]
+    return SA[-inv(p);]
 end

--- a/test/distributions/geometric_tests.jl
+++ b/test/distributions/geometric_tests.jl
@@ -61,3 +61,19 @@ end
         end
     end
 end
+
+# Regression test for issue #293: the default (mean) space gradient of the log-partition
+# must be the derivative of the default-space log-partition A(p) = -log(p), i.e. -1/p.
+# The previous implementation returned 1/(p^2 - p) = -1/(p(1-p)).
+@testitem "Geometric: default-space gradlogpartition consistency" begin
+    include("distributions_setuptests.jl")
+
+    logpartition_default = getlogpartition(DefaultParametersSpace(), Geometric)
+    gradlogpartition_default = getgradlogpartition(DefaultParametersSpace(), Geometric)
+
+    for p in (0.1, 0.3, 0.5, 0.8)
+        θ = [p]
+        @test gradlogpartition_default(θ) ≈ [-inv(p)]
+        @test gradlogpartition_default(θ) ≈ ForwardDiff.gradient(logpartition_default, θ)
+    end
+end


### PR DESCRIPTION
**[Verified audit fix]** — branch `fix/geometric-default-grad`.

Commit: `fix(Geometric): correct default-space gradlogpartition to -1/p`

## Changes

src/distributions/geometric.jl | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

## Verification

Confirmed against `main` in the ReactiveBayes audit (Julia 1.12.6); sources verified read-only. See the branch diff.
