### PR TITLE
Fix: invwishart default logpartition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix `InverseWishartFast` default-space `getlogpartition` using `mvtrigamma` instead of `logmvgamma` ([#295](https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/295)).
+
 ## [2.5.1]
 
 ### Fixed

--- a/src/distributions/wishart_inverse.jl
+++ b/src/distributions/wishart_inverse.jl
@@ -323,7 +323,7 @@ getfisherinformation(::NaturalParametersSpace, ::Type{InverseWishartFast}) =
 getlogpartition(::DefaultParametersSpace, ::Type{InverseWishartFast}) = (θ) -> begin
     (ν, S) = unpack_parameters(InverseWishartFast, θ)
     p = first(size(S))
-    return (ν / 2) * (p * log(2.0) - logdet(S)) + mvtrigamma(p, ν / 2)
+    return (ν / 2) * (p * log(2.0) - logdet(S)) + logmvgamma(p, ν / 2)
 end
 
 getfisherinformation(::DefaultParametersSpace, ::Type{InverseWishartFast}) =

--- a/test/distributions/wishart_inverse_tests.jl
+++ b/test/distributions/wishart_inverse_tests.jl
@@ -262,3 +262,24 @@ end
         end
     end
 end
+
+# Regression test for issue #295: the default (mean) space log-partition of
+# `InverseWishartFast` must equal the natural-space log-partition, since both
+# parametrizations describe the same distribution. The previous implementation used
+# `mvtrigamma` (sum of trigammas) instead of `logmvgamma`.
+@testitem "InverseWishartFast: default-space logpartition consistency" begin
+    include("distributions_setuptests.jl")
+    import ExponentialFamily: InverseWishartFast
+
+    for (ν, S) in ((6.0, [3.0 0.5; 0.5 2.0]), (9.0, [4.0 1.0 0.0; 1.0 3.0 0.5; 0.0 0.5 2.0]))
+        θ_tup = (ν, S)
+        η_tup = MeanToNatural(InverseWishartFast)(θ_tup)
+
+        θ = pack_parameters(DefaultParametersSpace(), InverseWishartFast, θ_tup)
+        η = pack_parameters(NaturalParametersSpace(), InverseWishartFast, η_tup)
+
+        lp_def = getlogpartition(DefaultParametersSpace(), InverseWishartFast)(θ)
+        lp_nat = getlogpartition(NaturalParametersSpace(), InverseWishartFast)(η)
+        @test lp_def ≈ lp_nat
+    end
+end


### PR DESCRIPTION
**[Verified audit fix]** — branch `fix/invwishart-default-logpartition`.

Commit: `fix(InverseWishart): use logmvgamma not mvtrigamma in default-space logpartition`

## Changes

src/distributions/wishart_inverse.jl | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

## Verification

Confirmed against `main` in the ReactiveBayes audit (Julia 1.12.6); sources verified read-only. See the branch diff.
