### PR TITLE
Fix DirichletCollection default-space logpartition (closes #300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix `DirichletCollection` default-space `getlogpartition` returning `0` instead of the per-slice partition sum ([#300](https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/300)).
+
 ## [2.5.1]
 
 ### Fixed

--- a/src/distributions/dirichlet_collection.jl
+++ b/src/distributions/dirichlet_collection.jl
@@ -277,10 +277,23 @@ end
 
 # Mean parametrization
 
-getlogpartition(::DefaultParametersSpace, ::Type{DirichletCollection}, conditioner) =
-    (η) -> begin
-        return mapreduce(x -> getlogpartition(DefaultParametersSpace(), Dirichlet)(x), +, η)
+function getlogpartition(::DefaultParametersSpace, ::Type{DirichletCollection}, conditioner::NTuple{N, Int}) where {N}
+    k = conditioner[1]  # Number of parameters per distribution
+    n_distributions = prod(Base.tail(conditioner))  # Total number of distributions
+    dirichlet_logpartition = getlogpartition(DefaultParametersSpace(), Dirichlet)
+
+    return function (θ::AbstractVector)
+        result = zero(eltype(θ))
+        for i in 1:n_distributions
+            idx_start = (i - 1) * k + 1
+            idx_end = i * k
+            @views params = θ[idx_start:idx_end]
+            result += dirichlet_logpartition(params)
+        end
+
+        return result
     end
+end
 
 function getgradlogpartition(::DefaultParametersSpace, ::Type{DirichletCollection}, conditioner::NTuple{N, Int}) where {N}
     k = conditioner[1]  # Number of parameters per distribution

--- a/test/distributions/dirichlet_collection_test.jl
+++ b/test/distributions/dirichlet_collection_test.jl
@@ -505,3 +505,25 @@ end
         @test @inferred(prod(strategy, d2, d3)) ≈ DirichletCollection([1.2000000000000002 3.3; 4.0 5.0; 2.0 1.1])
     end
 end
+
+# Regression test for issue #300: the default (mean) space log-partition iterated over the
+# flattened parameter vector element-by-element, feeding scalars to the multivariate
+# Dirichlet log-partition, so it identically returned 0. It must slice per-distribution and
+# agree with the natural-space log-partition.
+@testitem "DirichletCollection: default-space logpartition consistency" begin
+    include("distributions_setuptests.jl")
+
+    for α in ([1.2 3.3; 4.0 5.0; 2.0 1.1], rand(3, 4) .+ 1.0, rand(2, 3, 2) .+ 0.5)
+        d = DirichletCollection(α)
+        ef = convert(ExponentialFamilyDistribution, d)
+        η = getnaturalparameters(ef)
+        conditioner = getconditioner(ef)
+        θ = η .+ 1  # mean parameters (concentrations) = natural + 1
+
+        lp_nat = getlogpartition(NaturalParametersSpace(), DirichletCollection, conditioner)(η)
+        lp_def = getlogpartition(DefaultParametersSpace(), DirichletCollection, conditioner)(θ)
+
+        @test lp_def ≈ lp_nat
+        @test lp_def ≉ 0  # the previous implementation returned exactly 0
+    end
+end


### PR DESCRIPTION
Closes #300.

## Problem
`getlogpartition(DefaultParametersSpace(), DirichletCollection, conditioner)` mapped over the flattened parameter vector element-by-element and fed each **scalar** to the multivariate `Dirichlet` log-partition. For a scalar, `loggamma(x) - loggamma(x) = 0`, so the whole thing identically returned `0` regardless of input.

## Fix
Slice the flat vector per-distribution and sum the per-slice Dirichlet log-partition — mirroring the natural-space `getlogpartition` and the existing default-space `getgradlogpartition` in the same file.

## Test
Adds `DirichletCollection: default-space logpartition consistency`, asserting the default-space log-partition equals the natural-space one (and is not the previous constant `0`) across matrix and tensor shapes.

Reported by @docxology.