### PR TITLE
Add logpdf/pdf/cdf for TruncatedExponentialFamilyDistribution (closes #290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Implement `logpdf`/`pdf`/`cdf` for `TruncatedExponentialFamilyDistribution`, which previously threw a `MethodError`; also remove an unused import ([#290](https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/290)).
+
 ## [2.5.1]
 
 ### Fixed

--- a/src/truncate_univariate.jl
+++ b/src/truncate_univariate.jl
@@ -1,5 +1,5 @@
 export TruncatedExponentialFamilyDistribution
-import Distributions: _in_closed_interval, logsubexp
+import Distributions: _in_closed_interval
 
 struct TruncatedExponentialFamilyDistribution{
     D <: ExponentialFamilyDistribution{<:UnivariateDistribution},
@@ -138,3 +138,25 @@ function BayesBase.rand(rng::AbstractRNG, d::TruncatedExponentialFamilyDistribut
     end
 end
 
+
+### Density and distribution functions (issue #290)
+
+# Normalizing mass retained after truncation: P(l ≤ X ≤ u) = ucdf - lcdf.
+_truncated_lognorm(d::TruncatedExponentialFamilyDistribution) = log(d.ucdf - d.lcdf)
+
+# log-density of the truncated distribution. Outside the truncated support it is -Inf.
+function BayesBase.logpdf(d::TruncatedExponentialFamilyDistribution, x::Real)
+    if !insupport(d, x)
+        return convert(float(promote_type(typeof(x), typeof(d.lcdf))), -Inf)
+    end
+    return logpdf(d.untruncated, x) - _truncated_lognorm(d)
+end
+
+BayesBase.pdf(d::TruncatedExponentialFamilyDistribution, x::Real) = exp(logpdf(d, x))
+
+# cdf of the truncated distribution, clamped to [0, 1] so that values below the lower
+# bound map to 0 and values above the upper bound map to 1.
+function Distributions.cdf(d::TruncatedExponentialFamilyDistribution, x::Real)
+    result = (cdf(d.untruncated, x) - d.lcdf) / (d.ucdf - d.lcdf)
+    return clamp(result, zero(result), one(result))
+end

--- a/test/truncate_univariate_tests.jl
+++ b/test/truncate_univariate_tests.jl
@@ -59,3 +59,40 @@
         end
     end
 end
+
+# Regression test for issue #290: TruncatedExponentialFamilyDistribution previously
+# defined no logpdf/pdf/cdf, so `logpdf(dtr, x)` threw a MethodError. Compare the new
+# density/cdf against Distributions.truncated (ground truth) for continuous cases.
+@testitem "TruncateExponentialFamily: logpdf/pdf/cdf" begin
+    import BayesBase: logpdf, pdf
+    import Distributions: cdf, truncated
+
+    # Continuous: match Distributions.truncated exactly (P(X = boundary) = 0)
+    for (d, l, u) in ((Gamma(2.0, 2.0), 1.0, 5.0), (Weibull(1.5, 1.0), 0.5, 3.0))
+        d_ef = convert(ExponentialFamilyDistribution, d)
+        d_trunc = TruncatedExponentialFamilyDistribution(d_ef, l, u)
+        ref = truncated(d, l, u)
+
+        for x in range(l + 1e-3, u - 1e-3; length = 7)
+            @test logpdf(d_trunc, x) ≈ logpdf(ref, x)
+            @test pdf(d_trunc, x) ≈ pdf(ref, x)
+            @test cdf(d_trunc, x) ≈ cdf(ref, x)
+        end
+
+        # outside the truncated support
+        @test logpdf(d_trunc, l - 1.0) == -Inf
+        @test pdf(d_trunc, u + 1.0) == 0.0
+        @test cdf(d_trunc, l - 1.0) == 0.0
+        @test cdf(d_trunc, u + 1.0) == 1.0
+    end
+
+    # Discrete: the methods now exist (previously MethodError) and are self-consistent
+    d_trunc = TruncatedExponentialFamilyDistribution(convert(ExponentialFamilyDistribution, Poisson(3)), 1.0, 8.0)
+    @test hasmethod(logpdf, Tuple{typeof(d_trunc), Float64})
+    for x in 1:8
+        @test isfinite(logpdf(d_trunc, x))
+        @test pdf(d_trunc, x) ≈ exp(logpdf(d_trunc, x))
+    end
+    @test logpdf(d_trunc, 0) == -Inf
+    @test 0.0 <= cdf(d_trunc, 4) <= 1.0
+end


### PR DESCRIPTION
Closes #290. Also addresses #296 (7a).

## Problem
`TruncatedExponentialFamilyDistribution` is exported and subtypes `UnivariateDistribution`, but defined **no** `logpdf`/`pdf`/`cdf`, so `logpdf(dtr, x)` threw a `MethodError`. Downstream code that truncates an EF distribution and queries its density failed at runtime.

## Fix
Add the standard truncated density/cdf using the already-stored `lcdf`/`ucdf`:
- normalization `Z = ucdf - lcdf`
- `logpdf(d, x) = logpdf(untruncated, x) - log(Z)` (−Inf outside the truncated support)
- `pdf(d, x) = exp(logpdf(d, x))`
- `cdf(d, x) = clamp((cdf(untruncated, x) - lcdf) / Z, 0, 1)`

Also removes the unused `import Distributions: logsubexp` (issue #296, item 7a). The issue text suggested `logsubexp(ucdf, lcdf)`, but that computes `log(e^ucdf − e^lcdf)`, not `log(ucdf − lcdf)`; the plain `log(ucdf − lcdf)` is correct and needs no extra import.

## Test
New testitem compares the **continuous** case against `Distributions.truncated` (ground truth) for `logpdf`/`pdf`/`cdf` plus boundary behavior, and checks the **discrete** methods now exist and are self-consistent.

## Note for reviewer
For **discrete** untruncated distributions the constructor stores `lcdf = cdf(d, l) = P(X ≤ l)`, so the normalization `ucdf - lcdf = P(l < X ≤ u)` excludes the lower-bound mass `P(X = l)` even though `insupport` treats `[l, u]` as closed. That is a pre-existing lower-bound convention question in the constructor, independent of these density methods; flagging for a follow-up decision rather than changing truncation semantics here. cc @nimrais

Reported by @docxology.