### PR TITLE
Fix NegativeBinomial product normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Normalize products of two `NegativeBinomial` distributions over their full infinite support ([#299](https://github.com/ReactiveBayes/ExponentialFamily.jl/issues/299)).
+
 ## [2.5.1]
 
 ### Fixed

--- a/src/distributions/negative_binomial.jl
+++ b/src/distributions/negative_binomial.jl
@@ -1,6 +1,7 @@
 export NegativeBinomial
 import Distributions: NegativeBinomial, probs
 import StatsFuns: logit, logistic
+import LogExpFunctions: logsumexp
 import DomainSets: NaturalNumbers
 using StaticArrays
 
@@ -34,8 +35,26 @@ function BayesBase.prod(
         binomial_prod(p_x + p_left - 1, p_x + p_right - 1, p_x)
     end
 
+    # The NB×NB product has infinite support (x = 0, 1, 2, …), so the normalizer is an
+    # infinite sum. It is a terminating hypergeometric series only for special `r`; in
+    # general we sum until the terms become negligible. The summand is unimodal in `x`
+    # (log-binomials grow, `exp(η₁ x)` decays with η₁ < 0), so we accumulate in log-space
+    # and stop once a term falls a relative tolerance below the running peak.
     function logpartition(η)
-        return log(sum(binomial_prod(x + rleft - 1, x + rright - 1, x) * exp(η[1] * x) for x in 0:max(rright, rleft)))
+        η1 = η[1]
+        logtol = log(1e-12)
+        lterms = Float64[]
+        lmax = -Inf
+        x = 0
+        while true
+            lt = lchoose(x + rleft - 1, x) + lchoose(x + rright - 1, x) + η1 * x
+            push!(lterms, lt)
+            lmax = max(lmax, lt)
+            (x > 0 && lt < lmax + logtol) && break
+            x += 1
+            x > 1_000_000 && break # safety cap against a non-convergent (η₁ ≥ 0) input
+        end
+        return logsumexp(lterms)
     end
 
     supp = NaturalNumbers()

--- a/test/distributions/negative_binomial_tests.jl
+++ b/test/distributions/negative_binomial_tests.jl
@@ -65,7 +65,24 @@ end
             η_right = first(getnaturalparameters(efright))
             prod_dist = prod(PreserveTypeProd(ExponentialFamilyDistribution), left, right)
 
-            @test sum(pdf(prod_dist, x) for x in 0:max(nleft, nright)) ≈ 1.0 atol = 1e-5
+            @test sum(pdf(prod_dist, x) for x in 0:3000) ≈ 1.0 atol = 1e-6
         end
+    end
+end
+
+# Regression test for issue #299: the NB×NB product normalizer used to truncate the
+# (infinite) support at 0:max(r₁,r₂), so the density was mis-normalized whenever mass
+# extended beyond that. Sum the density over a range far wider than max(r₁,r₂).
+@testitem "NegativeBinomial: prod normalization over infinite support" begin
+    include("distributions_setuptests.jl")
+
+    for (nleft, nright, p) in ((10, 12, 0.5), (5, 6, 0.2), (30, 35, 0.3), (3, 4, 0.6))
+        left = NegativeBinomial(nleft, p)
+        right = NegativeBinomial(nright, p)
+        prod_dist = prod(PreserveTypeProd(ExponentialFamilyDistribution), left, right)
+
+        @test sum(pdf(prod_dist, x) for x in 0:3000) ≈ 1.0 atol = 1e-6
+        # the truncated range the old implementation used no longer captures all the mass
+        @test sum(pdf(prod_dist, x) for x in 0:max(nleft, nright)) < 1.0
     end
 end


### PR DESCRIPTION
## Summary
- normalize products of two `NegativeBinomial` distributions over their full infinite support
- accumulate normalizer terms in log space until the tail is negligible
- add regression coverage for probability mass beyond the former truncated range
- document the fix in the changelog

Closes #299

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test(test_args=["negative_binomial"])'`\n- Full suite passed: 271/271 test items, 262487/262487 assertions