### PR TITLE
CI: update actions for Node 24

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,19 +29,19 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with:
           include-all-prereleases: true
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_FASTCHOLESKY_THROW_ERROR_NON_SYMMETRIC: 1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v7
         with:
           files: lcov.info
         env:
@@ -51,11 +51,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@v7
+      - uses: julia-actions/setup-julia@v3
         with: 
           version: '1'
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         env:
           cache-name: cache-artifacts
         with:


### PR DESCRIPTION
## Summary

- update `actions/checkout` from v2 to v7
- update `julia-actions/setup-julia` from v2 to v3
- update `julia-actions/cache` from v2 to v3
- update `actions/cache` from v4 to v6 in the documentation job
- update `codecov/codecov-action` from v4 to v7

## Motivation

GitHub-hosted runners now force actions targeting Node.js 20 to run on Node.js 24 and emit deprecation warnings. These updates move the affected CI steps to their current Node.js 24-compatible major versions.

This PR intentionally does not change tests, benchmarks, or package code.

## Validation

- `git diff --check`
- parsed `.github/workflows/CI.yml` with Ruby YAML
- reviewed upstream release notes for the updated major versions